### PR TITLE
Add WriteFreely model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Post editor now has a Publish button to change post status 
 - Collections sidebar to choose a specific collection (i.e., blog)
 - Settings to provide the user interface for logging in, setting preferred color scheme 
+- The WriteFreelyModel type consolidates other models as Published properties in a single EnvironmentObject
+- Logging in and out a WriteFreely instance is now possible
 
 ### Changed
 
 - Updated license from AGPLv3 to GPLv3
+- Types have been renamed to be more consistent
+- WriteFreely Swift package version bumped to v0.2.1
 
 ## [0.0.2] - 2020-07-30
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ These instructions will get you a copy of the project up and running on your loc
 
 ### Prerequisites
 
-⚠️ Building and testing the iOS targets will work on any version of macOS that supports Xcode 12, but building and testing the macOS target requires macOS 11 (Big Sur).
+⚠️ Building and testing the iOS targets will work on any version of macOS that supports Xcode 12, but building and testing the macOS target requires macOS 11 (Big Sur) beta 5.
 
-- Xcode 12 (currently in beta)
+- Xcode 12 beta 5
 - [SwiftLint](https://github.com/realm/SwiftLint)
 
 SwiftLint is run as a build phase for all targets, so that linting warnings and errors are shown in Xcode.
@@ -36,4 +36,4 @@ See also the list of [contributors](https://github.com/writeas/writefreely-swift
 
 ## License
 
-This project is licensed under the AGPL v3 License. See the [LICENSE.md](LICENSE.md) file for details.
+This project is licensed under the GPL v3 License. See the [LICENSE.md](LICENSE.md) file for details.

--- a/Shared/Account/AccountLoginView.swift
+++ b/Shared/Account/AccountLoginView.swift
@@ -1,65 +1,66 @@
 import SwiftUI
 
 struct AccountLoginView: View {
-    @ObservedObject var account: AccountModel
+    @EnvironmentObject var model: WriteFreelyModel
 
     @State private var isShowingAlert: Bool = false
     @State private var alertMessage: String = ""
-
+    @State private var username: String = ""
+    @State private var password: String = ""
+    @State private var server: String = ""
     var body: some View {
         VStack {
             HStack {
                 Image(systemName: "person.circle")
                     .foregroundColor(.gray)
                 #if os(iOS)
-                TextField("Username", text: $account.username)
+                TextField("Username", text: $username)
                     .autocapitalization(.none)
                     .disableAutocorrection(true)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                 #else
-                TextField("Username", text: $account.username)
+                TextField("Username", text: $username)
                 #endif
             }
             HStack {
                 Image(systemName: "lock.circle")
                     .foregroundColor(.gray)
                 #if os(iOS)
-                SecureField("Password", text: $account.password)
+                SecureField("Password", text: $password)
                     .autocapitalization(.none)
                     .disableAutocorrection(true)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                 #else
-                SecureField("Password", text: $account.password)
+                SecureField("Password", text: $password)
                 #endif
             }
             HStack {
                 Image(systemName: "link.circle")
                     .foregroundColor(.gray)
                 #if os(iOS)
-                TextField("Server URL", text: $account.server)
+                TextField("Server URL", text: $server)
                     .keyboardType(.URL)
                     .autocapitalization(.none)
                     .disableAutocorrection(true)
                     .textFieldStyle(RoundedBorderTextFieldStyle())
                 #else
-                TextField("Server URL", text: $account.server)
+                TextField("Server URL", text: $server)
                 #endif
             }
             Spacer()
-            if account.isLoggingIn {
+            if model.isLoggingIn {
                 ProgressView("Logging in...")
                     .padding()
             } else {
                 Button(action: {
-                    account.login(
-                        to: account.server,
-                        as: account.username, password: account.password,
-                        completion: loginHandler
+                    model.login(
+                        to: URL(string: server)!,
+                        as: username, password: password
                     )
                 }, label: {
                     Text("Login")
                 })
-                .disabled(account.isLoggedIn)
+                .disabled(model.account.isLoggedIn)
                 .padding()
             }
         }
@@ -99,6 +100,7 @@ struct AccountLoginView: View {
 
 struct AccountLoginView_Previews: PreviewProvider {
     static var previews: some View {
-        AccountLoginView(account: AccountModel())
+        AccountLoginView()
+            .environmentObject(WriteFreelyModel())
     }
 }

--- a/Shared/Account/AccountLoginView.swift
+++ b/Shared/Account/AccountLoginView.swift
@@ -69,33 +69,9 @@ struct AccountLoginView: View {
         .alert(isPresented: $isShowingAlert) {
             Alert(
                 title: Text("Error Logging In"),
-                message: Text(alertMessage),
+                message: Text(accountError.localizedDescription),
                 dismissButton: .default(Text("OK"))
             )
-        }
-    }
-
-    func loginHandler(result: Result<UUID, AccountError>) {
-        do {
-            _ = try result.get()
-        } catch AccountError.serverNotFound {
-            alertMessage = """
-            The server could not be found. Please check that you've entered the information correctly and try again.
-            """
-            isShowingAlert = true
-        } catch AccountError.invalidPassword {
-            alertMessage = """
-            Invalid password. Please check that you've entered your password correctly and try logging in again.
-            """
-            isShowingAlert = true
-        } catch AccountError.usernameNotFound {
-            alertMessage = """
-            Username not found. Did you use your email address by mistake?
-            """
-            isShowingAlert = true
-        } catch {
-            alertMessage = "An unknown error occurred. Please try again."
-            isShowingAlert = true
         }
     }
 }

--- a/Shared/Account/AccountLoginView.swift
+++ b/Shared/Account/AccountLoginView.swift
@@ -60,7 +60,9 @@ struct AccountLoginView: View {
                 }, label: {
                     Text("Login")
                 })
-                .disabled(model.account.isLoggedIn)
+                .disabled(
+                    model.account.isLoggedIn || (username.isEmpty || password.isEmpty || server.isEmpty)
+                )
                 .padding()
             }
         }

--- a/Shared/Account/AccountLoginView.swift
+++ b/Shared/Account/AccountLoginView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct AccountLoginView: View {
     @EnvironmentObject var model: WriteFreelyModel
 
-    @State private var isShowingAlert: Bool = false
     @State private var alertMessage: String = ""
     @State private var username: String = ""
     @State private var password: String = ""
@@ -66,8 +65,9 @@ struct AccountLoginView: View {
                 .padding()
             }
         }
-        .alert(isPresented: $isShowingAlert) {
-            Alert(
+        .alert(isPresented: $model.account.hasError) {
+            guard let accountError = model.account.currentError else { fatalError() }
+            return Alert(
                 title: Text("Error Logging In"),
                 message: Text(accountError.localizedDescription),
                 dismissButton: .default(Text("OK"))

--- a/Shared/Account/AccountLogoutView.swift
+++ b/Shared/Account/AccountLogoutView.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
 struct AccountLogoutView: View {
-    @ObservedObject var account: AccountModel
+    @EnvironmentObject var model: WriteFreelyModel
 
     var body: some View {
         VStack {
             Spacer()
             VStack {
-                Text("Logged in as \(account.username)")
-                Text("on \(account.server)")
+                Text("Logged in as \(model.account.user?.username ?? "Anonymous")")
+                Text("on \(model.account.server)")
             }
             Spacer()
             Button(action: logoutHandler, label: {
@@ -18,12 +18,13 @@ struct AccountLogoutView: View {
     }
 
     func logoutHandler() {
-        account.logout()
+        model.logout()
     }
 }
 
 struct AccountLogoutView_Previews: PreviewProvider {
     static var previews: some View {
-        AccountLogoutView(account: AccountModel())
+        AccountLogoutView()
+            .environmentObject(WriteFreelyModel())
     }
 }

--- a/Shared/Account/AccountModel.swift
+++ b/Shared/Account/AccountModel.swift
@@ -7,6 +7,28 @@ enum AccountError: Error {
     case serverNotFound
 }
 
+extension AccountError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .serverNotFound:
+            return NSLocalizedString(
+                "The server could not be found. Please check the information you've entered and try again.",
+                comment: ""
+            )
+        case .invalidPassword:
+            return NSLocalizedString(
+                "Invalid password. Please check that you've entered your password correctly and try logging in again.",
+                comment: ""
+            )
+        case .usernameNotFound:
+            return NSLocalizedString(
+                "Username not found. Did you use your email address by mistake?",
+                comment: ""
+            )
+        }
+    }
+}
+
 struct AccountModel {
     var server: String = ""
     private(set) var user: WFUser?

--- a/Shared/Account/AccountModel.swift
+++ b/Shared/Account/AccountModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WriteFreely
 
 enum AccountError: Error {
     case invalidPassword
@@ -6,66 +7,18 @@ enum AccountError: Error {
     case serverNotFound
 }
 
-class AccountModel: ObservableObject {
-    @Published private(set) var id: UUID?
-    @Published private(set) var isLoggedIn: Bool = false
-    @Published private(set) var isLoggingIn: Bool = false
-    @Published var username: String = ""
-    @Published var password: String = ""
-    @Published var server: String = ""
+struct AccountModel {
+    var server: String = ""
+    private(set) var user: WFUser?
+    private(set) var isLoggedIn: Bool = false
 
-    func login(
-        to server: String,
-        as username: String,
-        password: String,
-        completion: @escaping (Result<UUID, AccountError>) -> Void
-    ) {
-        self.isLoggingIn = true
-        let result: Result<UUID, AccountError>
-
-        if server != validServer {
-            result = .failure(.serverNotFound)
-        } else if username != validCredentials["username"] {
-            result = .failure(.usernameNotFound)
-        } else if password != validCredentials["password"] {
-            result = .failure(.invalidPassword)
-        } else {
-            self.id = UUID()
-            self.username = username
-            self.password = password
-            self.server = server
-            result = .success(self.id!)
-        }
-
-        #if DEBUG
-        // Delay to simulate async network call
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            self.isLoggingIn = false
-            do {
-                _ = try result.get()
-                self.isLoggedIn = true
-            } catch {
-                self.isLoggedIn = false
-            }
-            completion(result)
-        }
-        #endif
+    mutating func login(_ user: WFUser) {
+        self.user = user
+        self.isLoggedIn = true
     }
 
-    func logout() {
-        id = nil
-        isLoggedIn = false
-        isLoggingIn = false
-        username = ""
-        password = ""
-        server = ""
+    mutating func logout() {
+        self.user = nil
+        self.isLoggedIn = false
     }
 }
-
-#if DEBUG
-let validCredentials = [
-    "username": "test-writer",
-    "password": "12345"
-]
-let validServer = "https://test.server.url"
-#endif

--- a/Shared/Account/AccountModel.swift
+++ b/Shared/Account/AccountModel.swift
@@ -31,6 +31,12 @@ extension AccountError: LocalizedError {
 
 struct AccountModel {
     var server: String = ""
+    var hasError: Bool = false
+    var currentError: AccountError? {
+        didSet {
+            hasError = true
+        }
+    }
     private(set) var user: WFUser?
     private(set) var isLoggedIn: Bool = false
 

--- a/Shared/Account/AccountView.swift
+++ b/Shared/Account/AccountView.swift
@@ -1,18 +1,18 @@
 import SwiftUI
 
 struct AccountView: View {
-    @ObservedObject var account: AccountModel
+    @EnvironmentObject var model: WriteFreelyModel
 
     var body: some View {
-        if account.isLoggedIn {
+        if model.account.isLoggedIn {
             HStack {
                 Spacer()
-                AccountLogoutView(account: account)
+                AccountLogoutView()
                 Spacer()
             }
             .padding()
         } else {
-            AccountLoginView(account: account)
+            AccountLoginView()
                 .padding()
         }
     }
@@ -20,6 +20,7 @@ struct AccountView: View {
 
 struct AccountLogin_Previews: PreviewProvider {
     static var previews: some View {
-        AccountView(account: AccountModel())
+        AccountView()
+            .environmentObject(WriteFreelyModel())
     }
 }

--- a/Shared/Models/PostStore.swift
+++ b/Shared/Models/PostStore.swift
@@ -1,15 +1,13 @@
 import Foundation
 
-class PostStore: ObservableObject {
-    @Published var posts: [Post]
+struct PostStore {
+    var posts: [Post]
 
     init(posts: [Post] = []) {
         self.posts = posts
     }
 
-    func add(_ post: Post) {
+    mutating func add(_ post: Post) {
         posts.append(post)
     }
 }
-
-var testPostStore = PostStore(posts: testPostData)

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+// MARK: - WriteFreelyModel
+
+class WriteFreelyModel: ObservableObject {
+    @Published var account = AccountModel()
+    @Published var preferences = PreferencesModel()
+    @Published var store = PostStore()
+    @Published var post: Post?
+
+    init() {
+        #if DEBUG
+        for post in testPostData { store.add(post) }
+        #endif
+    }
+}
+
+// MARK: - WriteFreelyModel API
+
+extension WriteFreelyModel {
+    // API goes here
+}

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WriteFreely
 
 // MARK: - WriteFreelyModel
 
@@ -7,6 +8,9 @@ class WriteFreelyModel: ObservableObject {
     @Published var preferences = PreferencesModel()
     @Published var store = PostStore()
     @Published var post: Post?
+    @Published var isLoggingIn: Bool = false
+
+    private var client: WFClient?
 
     init() {
         #if DEBUG
@@ -18,5 +22,44 @@ class WriteFreelyModel: ObservableObject {
 // MARK: - WriteFreelyModel API
 
 extension WriteFreelyModel {
-    // API goes here
+    func login(
+        to server: URL,
+        as username: String,
+        password: String
+    ) {
+        isLoggingIn = true
+        account.server = server.absoluteString
+        client = WFClient(for: server)
+        client?.login(username: username, password: password, completion: loginHandler)
+    }
+
+    func logout () {
+        guard let loggedInClient = client else { return }
+        loggedInClient.logout(completion: logoutHandler)
+    }
+}
+
+private extension WriteFreelyModel {
+    func loginHandler(result: Result<WFUser, Error>) {
+        isLoggingIn = false
+        do {
+            let user = try result.get()
+            account.login(user)
+            dump(user)
+        } catch {
+            dump(error)
+        }
+    }
+
+    func logoutHandler(result: Result<Bool, Error>) {
+        do {
+            let loggedOut = try result.get()
+            if loggedOut {
+                client = nil
+                account.logout()
+            }
+        } catch {
+            dump(error)
+        }
+    }
 }

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -1,9 +1,7 @@
 import SwiftUI
 
 struct ContentView: View {
-    @ObservedObject var postStore: PostStore
-    @ObservedObject var preferences: PreferencesModel
-    @ObservedObject var account: AccountModel
+    @EnvironmentObject var model: WriteFreelyModel
 
     var body: some View {
         NavigationView {
@@ -14,14 +12,13 @@ struct ContentView: View {
             Text("Select a post, or create a new draft.")
                 .foregroundColor(.secondary)
         }
-        .environmentObject(postStore)
-        .environmentObject(preferences)
-        .environmentObject(account)
+        .environmentObject(model)
     }
 }
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView(postStore: testPostStore, preferences: PreferencesModel(), account: AccountModel())
+        ContentView()
+            .environmentObject(WriteFreelyModel())
     }
 }

--- a/Shared/PostEditor/PostEditorView.swift
+++ b/Shared/PostEditor/PostEditorView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct PostEditorView: View {
-    @EnvironmentObject var postStore: PostStore
+    @EnvironmentObject var model: WriteFreelyModel
 
     @ObservedObject var post: Post
 
@@ -47,12 +47,12 @@ struct PostEditorView: View {
     }
 
     private func checkIfNewPost() {
-        self.isNewPost = !postStore.posts.contains(where: { $0.id == post.id })
+        self.isNewPost = !model.store.posts.contains(where: { $0.id == post.id })
     }
 
     private func addNewPostToStore() {
         withAnimation {
-            postStore.add(post)
+            model.store.add(post)
             self.isNewPost = false
         }
     }
@@ -61,13 +61,13 @@ struct PostEditorView: View {
 struct PostEditorView_NewDraftPreviews: PreviewProvider {
     static var previews: some View {
         PostEditorView(post: Post())
-            .environmentObject(testPostStore)
+            .environmentObject(WriteFreelyModel())
     }
 }
 
 struct PostEditorView_ExistingPostPreviews: PreviewProvider {
     static var previews: some View {
         PostEditorView(post: testPostData[0])
-            .environmentObject(testPostStore)
+            .environmentObject(WriteFreelyModel())
     }
 }

--- a/Shared/PostList/PostCellView.swift
+++ b/Shared/PostList/PostCellView.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
 struct PostCellView: View {
-    @EnvironmentObject var postStore: PostStore
-
     @ObservedObject var post: Post
 
     var body: some View {

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
 struct PostListView: View {
-    @EnvironmentObject var postStore: PostStore
-
+    @EnvironmentObject var model: WriteFreelyModel
     @State var selectedCollection: PostCollection
 
     #if os(iOS)
@@ -23,12 +22,13 @@ struct PostListView: View {
                     }
                 }
             }
+            .environmentObject(model)
             .navigationTitle(selectedCollection.title)
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button(action: {
                         let post = Post()
-                        postStore.add(post)
+                        model.store.add(post)
                     }, label: {
                         Image(systemName: "square.and.pencil")
                     })
@@ -74,7 +74,7 @@ struct PostListView: View {
         .toolbar {
             Button(action: {
                 let post = Post()
-                postStore.add(post)
+                model.store.add(post)
             }, label: {
                 Image(systemName: "square.and.pencil")
             })
@@ -92,9 +92,9 @@ struct PostListView: View {
 
     private func showPosts(for collection: PostCollection) -> [Post] {
         if collection == allPostsCollection {
-            return postStore.posts
+            return model.store.posts
         } else {
-            return postStore.posts.filter {
+            return model.store.posts.filter {
                 $0.collection.title == collection.title
             }
         }
@@ -105,7 +105,7 @@ struct PostList_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             PostListView(selectedCollection: allPostsCollection)
-                .environmentObject(testPostStore)
+                .environmentObject(WriteFreelyModel())
         }
     }
 }

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -2,35 +2,29 @@ import SwiftUI
 
 @main
 struct WriteFreely_MultiPlatformApp: App {
-    @StateObject private var preferences = PreferencesModel()
-    @StateObject private var account = AccountModel()
+    @StateObject private var model = WriteFreelyModel()
 
     #if os(macOS)
     @State private var selectedTab = 0
     #endif
 
-    #if DEBUG
-    @StateObject private var store = testPostStore
-    #else
-    @StateObject private var store = PostStore()
-    #endif
-
     var body: some Scene {
         WindowGroup {
-            ContentView(postStore: store, preferences: preferences, account: account)
+            ContentView()
+                .environmentObject(model)
 //                .preferredColorScheme(preferences.selectedColorScheme)    // See PreferencesModel for info.
         }
 
         #if os(macOS)
         Settings {
             TabView(selection: $selectedTab) {
-                MacAccountView(account: account)
+                MacAccountView(account: model.account)
                     .tabItem {
                         Image(systemName: "person.crop.circle")
                         Text("Account")
                     }
                     .tag(0)
-                MacPreferencesView(preferences: preferences)
+                MacPreferencesView(preferences: model.preferences)
                     .tabItem {
                         Image(systemName: "gear")
                         Text("Preferences")

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -18,7 +18,8 @@ struct WriteFreely_MultiPlatformApp: App {
         #if os(macOS)
         Settings {
             TabView(selection: $selectedTab) {
-                MacAccountView(account: model.account)
+                MacAccountView()
+                    .environmentObject(model)
                     .tabItem {
                         Image(systemName: "person.crop.circle")
                         Text("Account")

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		171BFDF824D49FD400888236 /* PostCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171BFDF624D49FD400888236 /* PostCollection.swift */; };
 		171BFDFA24D4AF8300888236 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171BFDF924D4AF8300888236 /* CollectionListView.swift */; };
 		171BFDFB24D4AF8300888236 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171BFDF924D4AF8300888236 /* CollectionListView.swift */; };
+		174D313224EC2831006CA9EE /* WriteFreelyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174D313124EC2831006CA9EE /* WriteFreelyModel.swift */; };
+		174D313324EC2831006CA9EE /* WriteFreelyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174D313124EC2831006CA9EE /* WriteFreelyModel.swift */; };
 		1753F6AC24E431CC00309365 /* MacPreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1753F6AB24E431CC00309365 /* MacPreferencesView.swift */; };
 		1756AE6B24CB1E4B00FD7257 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756AE6A24CB1E4B00FD7257 /* Post.swift */; };
 		1756AE6C24CB1E4B00FD7257 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756AE6A24CB1E4B00FD7257 /* Post.swift */; };
@@ -80,6 +82,7 @@
 		17120DB124E1E19C002B9F6C /* SettingsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
 		171BFDF624D49FD400888236 /* PostCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCollection.swift; sourceTree = "<group>"; };
 		171BFDF924D4AF8300888236 /* CollectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionListView.swift; sourceTree = "<group>"; };
+		174D313124EC2831006CA9EE /* WriteFreelyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteFreelyModel.swift; sourceTree = "<group>"; };
 		1753F6AB24E431CC00309365 /* MacPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacPreferencesView.swift; sourceTree = "<group>"; };
 		1756AE6A24CB1E4B00FD7257 /* Post.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Post.swift; sourceTree = "<group>"; };
 		1756AE6D24CB255B00FD7257 /* PostStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStore.swift; sourceTree = "<group>"; };
@@ -181,6 +184,7 @@
 				1756AE6A24CB1E4B00FD7257 /* Post.swift */,
 				171BFDF624D49FD400888236 /* PostCollection.swift */,
 				1756AE6D24CB255B00FD7257 /* PostStore.swift */,
+				174D313124EC2831006CA9EE /* WriteFreelyModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -555,6 +559,7 @@
 				17120DA224E1985C002B9F6C /* AccountModel.swift in Sources */,
 				17120DA324E19A42002B9F6C /* PreferencesView.swift in Sources */,
 				1756AE6E24CB255B00FD7257 /* PostStore.swift in Sources */,
+				174D313224EC2831006CA9EE /* WriteFreelyModel.swift in Sources */,
 				1756AE6B24CB1E4B00FD7257 /* Post.swift in Sources */,
 				17120DA124E19839002B9F6C /* AccountView.swift in Sources */,
 				1756AE7424CB26FA00FD7257 /* PostCellView.swift in Sources */,
@@ -568,6 +573,7 @@
 				171BFDF824D49FD400888236 /* PostCollection.swift in Sources */,
 				17DF32AD24C87D3500BCE2E3 /* ContentView.swift in Sources */,
 				1765F62B24E18EA200C9EBF0 /* SidebarView.swift in Sources */,
+				174D313324EC2831006CA9EE /* WriteFreelyModel.swift in Sources */,
 				1756AE7824CB2EDD00FD7257 /* PostEditorView.swift in Sources */,
 				17D435E924E3128F0036B539 /* PreferencesModel.swift in Sources */,
 				17120DAA24E1B2F5002B9F6C /* AccountLogoutView.swift in Sources */,

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -800,7 +800,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.16;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abunchtell.WriteFreely-MultiPlatform";
 				PRODUCT_NAME = "WriteFreely-MultiPlatform";
 				SDKROOT = macosx;
@@ -824,7 +825,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.16;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MARKETING_VERSION = 0.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.abunchtell.WriteFreely-MultiPlatform";
 				PRODUCT_NAME = "WriteFreely-MultiPlatform";
 				SDKROOT = macosx;

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/iOS/Settings/SettingsView.swift
+++ b/iOS/Settings/SettingsView.swift
@@ -1,8 +1,7 @@
 import SwiftUI
 
 struct SettingsView: View {
-    @EnvironmentObject var preferences: PreferencesModel
-    @EnvironmentObject var account: AccountModel
+    @EnvironmentObject var model: WriteFreelyModel
 
     @Binding var isPresented: Bool
 
@@ -11,10 +10,10 @@ struct SettingsView: View {
             SettingsHeaderView(isPresented: $isPresented)
             Form {
                 Section(header: Text("Login Details")) {
-                    AccountView(account: account)
+                    AccountView(account: model.account)
                 }
                 Section(header: Text("Appearance")) {
-                    PreferencesView(preferences: preferences)
+                    PreferencesView(preferences: model.preferences)
                 }
             }
         }
@@ -25,5 +24,6 @@ struct SettingsView: View {
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
         SettingsView(isPresented: .constant(true))
+            .environmentObject(WriteFreelyModel())
     }
 }

--- a/iOS/Settings/SettingsView.swift
+++ b/iOS/Settings/SettingsView.swift
@@ -10,7 +10,7 @@ struct SettingsView: View {
             SettingsHeaderView(isPresented: $isPresented)
             Form {
                 Section(header: Text("Login Details")) {
-                    AccountView(account: model.account)
+                    AccountView()
                 }
                 Section(header: Text("Appearance")) {
                     PreferencesView(preferences: model.preferences)

--- a/macOS/Info.plist
+++ b/macOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>

--- a/macOS/Settings/MacAccountView.swift
+++ b/macOS/Settings/MacAccountView.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
 struct MacAccountView: View {
-    @ObservedObject var account: AccountModel
+    @EnvironmentObject var model: WriteFreelyModel
 
     var body: some View {
             Form {
                 Section(header: Text("Login Details")) {
-                    AccountView(account: account)
+                    AccountView()
                 }
             }
     }
@@ -14,6 +14,7 @@ struct MacAccountView: View {
 
 struct MacAccountView_Previews: PreviewProvider {
     static var previews: some View {
-        MacAccountView(account: AccountModel())
+        MacAccountView()
+            .environmentObject(WriteFreelyModel())
     }
 }

--- a/macOS/macOS.entitlements
+++ b/macOS/macOS.entitlements
@@ -2,9 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.app-sandbox</key>
-    <true/>
-    <key>com.apple.security.files.user-selected.read-only</key>
-    <true/>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #6.

This PR begins the work of consolidating various models as Published properties in a single EnvironmentObject, and kicks off work on a consolidated API for working with WriteFreely instances.

It also implements login/logout functionality as an example of this API (the access token is only stored in memory, however, so login/logout should not be considered feature complete until we have persistence in the system Keychain).