### PR TITLE
Persist logged-in state between app launches

### DIFF
--- a/Shared/Account/AccountLogoutView.swift
+++ b/Shared/Account/AccountLogoutView.swift
@@ -7,7 +7,7 @@ struct AccountLogoutView: View {
         VStack {
             Spacer()
             VStack {
-                Text("Logged in as \(model.account.user?.username ?? "Anonymous")")
+                Text("Logged in as \(model.account.username ?? "Anonymous")")
                 Text("on \(model.account.server)")
             }
             Spacer()

--- a/Shared/Account/AccountModel.swift
+++ b/Shared/Account/AccountModel.swift
@@ -30,6 +30,11 @@ extension AccountError: LocalizedError {
 }
 
 struct AccountModel {
+    private let defaults = UserDefaults.standard
+    let isLoggedInFlag = "isLoggedInFlag"
+    let usernameStringKey = "usernameStringKey"
+    let serverStringKey = "serverStringKey"
+
     var server: String = ""
     var hasError: Bool = false
     var currentError: AccountError? {
@@ -43,10 +48,16 @@ struct AccountModel {
     mutating func login(_ user: WFUser) {
         self.user = user
         self.isLoggedIn = true
+        defaults.set(true, forKey: isLoggedInFlag)
+        defaults.set(user.username, forKey: usernameStringKey)
+        defaults.set(server, forKey: serverStringKey)
     }
 
     mutating func logout() {
         self.user = nil
         self.isLoggedIn = false
+        defaults.set(false, forKey: isLoggedInFlag)
+        defaults.removeObject(forKey: usernameStringKey)
+        defaults.removeObject(forKey: serverStringKey)
     }
 }

--- a/Shared/Account/AccountModel.swift
+++ b/Shared/Account/AccountModel.swift
@@ -36,6 +36,7 @@ struct AccountModel {
     let serverStringKey = "serverStringKey"
 
     var server: String = ""
+    var username: String = ""
     var hasError: Bool = false
     var currentError: AccountError? {
         didSet {
@@ -47,6 +48,7 @@ struct AccountModel {
 
     mutating func login(_ user: WFUser) {
         self.user = user
+        self.username = user.username ?? ""
         self.isLoggedIn = true
         defaults.set(true, forKey: isLoggedInFlag)
         defaults.set(user.username, forKey: usernameStringKey)
@@ -59,5 +61,11 @@ struct AccountModel {
         defaults.set(false, forKey: isLoggedInFlag)
         defaults.removeObject(forKey: usernameStringKey)
         defaults.removeObject(forKey: serverStringKey)
+    }
+
+    mutating func restoreState() {
+        isLoggedIn = defaults.bool(forKey: isLoggedInFlag)
+        server = defaults.string(forKey: serverStringKey) ?? ""
+        username = defaults.string(forKey: usernameStringKey) ?? ""
     }
 }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -17,6 +17,10 @@ class WriteFreelyModel: ObservableObject {
         #if DEBUG
         for post in testPostData { store.add(post) }
         #endif
+
+        DispatchQueue.main.async {
+            self.account.restoreState()
+        }
     }
 }
 
@@ -31,7 +35,15 @@ extension WriteFreelyModel {
     }
 
     func logout() {
-        guard let loggedInClient = client else { return }
+        guard let loggedInClient = client else {
+            do {
+                try purgeTokenFromKeychain(username: account.username, server: account.server)
+                account.logout()
+            } catch {
+                fatalError("Failed to log out persisted state")
+            }
+            return
+        }
         loggedInClient.logout(completion: logoutHandler)
     }
 }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -23,18 +23,14 @@ class WriteFreelyModel: ObservableObject {
 // MARK: - WriteFreelyModel API
 
 extension WriteFreelyModel {
-    func login(
-        to server: URL,
-        as username: String,
-        password: String
-    ) {
+    func login(to server: URL, as username: String, password: String) {
         isLoggingIn = true
         account.server = server.absoluteString
         client = WFClient(for: server)
         client?.login(username: username, password: password, completion: loginHandler)
     }
 
-    func logout () {
+    func logout() {
         guard let loggedInClient = client else { return }
         loggedInClient.logout(completion: logoutHandler)
     }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WriteFreely
+import Security
 
 // MARK: - WriteFreelyModel
 
@@ -93,5 +94,65 @@ private extension WriteFreelyModel {
                 }
             }
         }
+    }
+}
+
+private extension WriteFreelyModel {
+    // MARK: - Keychain Helpers
+    func saveTokenToKeychain(_ token: String, username: String?, server: String) {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecValueData as String: token.data(using: .utf8)!,
+            kSecAttrAccount as String: username ?? "anonymous",
+            kSecAttrService as String: server
+        ]
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        guard status == errSecDuplicateItem || status == errSecSuccess else {
+            fatalError("Error storing in Keychain with OSStatus: \(status)")
+        }
+    }
+
+    func purgeTokenFromKeychain(username: String?, server: String) throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: username ?? "anonymous",
+            kSecAttrService as String: server
+        ]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            fatalError("Error deleting from Keychain with OSStatus: \(status)")
+        }
+    }
+
+    func fetchTokenFromKeychain(username: String?, server: String) -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: username ?? "anonymous",
+            kSecAttrService as String: server,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnAttributes as String: true,
+            kSecReturnData as String: true
+        ]
+
+        var secItem: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &secItem)
+
+        guard status != errSecItemNotFound else {
+            return nil
+        }
+
+        guard status == errSecSuccess else {
+            fatalError("Error fetching from Keychain with OSStatus: \(status)")
+        }
+
+        guard let existingSecItem = secItem as? [String: Any],
+              let tokenData = existingSecItem[kSecValueData as String] as? Data,
+              let token = String(data: tokenData, encoding: .utf8) else {
+            return nil
+        }
+
+        return token
     }
 }


### PR DESCRIPTION
Closes #8.

This PR handles persistence for logged-in state in two ways.

## Via the Keychain

When logging in, the user's access token is saved to the Keychain; when logging out, that Keychain entry is destroyed. A helper method for fetching the token is also part of this work; all Keychain helpers live in the WriteFreelyModel extension.

## Via UserDefaults

For non-sensitive data, we also want to persist state so that we can fetch tokens from the Keychain between app launches (since the WF client, which has a user property, is only kept in-memory). We therefore persist the `isLoggedIn`, `server`, and `username` properties in UserDefaults, and restore these values on launch.