### PR TITLE
Persist preferences between app launches

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -11,8 +11,14 @@ class WriteFreelyModel: ObservableObject {
     @Published var isLoggingIn: Bool = false
 
     private var client: WFClient?
+    private let defaults = UserDefaults.standard
 
     init() {
+        // Set the color scheme based on what's been saved in UserDefaults.
+        DispatchQueue.main.async {
+            self.preferences.appearance = self.defaults.integer(forKey: self.preferences.colorSchemeIntegerKey)
+        }
+
         #if DEBUG
         for post in testPostData { store.add(post) }
         #endif

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -22,18 +22,14 @@ class WriteFreelyModel: ObservableObject {
 // MARK: - WriteFreelyModel API
 
 extension WriteFreelyModel {
-    func login(
-        to server: URL,
-        as username: String,
-        password: String
-    ) {
+    func login(to server: URL, as username: String, password: String) {
         isLoggingIn = true
         account.server = server.absoluteString
         client = WFClient(for: server)
         client?.login(username: username, password: password, completion: loginHandler)
     }
 
-    func logout () {
+    func logout() {
         guard let loggedInClient = client else { return }
         loggedInClient.logout(completion: logoutHandler)
     }

--- a/Shared/Preferences/PreferencesModel.swift
+++ b/Shared/Preferences/PreferencesModel.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 class PreferencesModel: ObservableObject {
+    private let defaults = UserDefaults.standard
+    let colorSchemeIntegerKey = "colorSchemeIntegerKey"
+
     /* We're stuck dropping into AppKit/UIKit to set light/dark schemes for now,
      * because setting the .preferredColorScheme modifier on views in SwiftUI is
      * currently unreliable.
@@ -49,6 +52,8 @@ class PreferencesModel: ObservableObject {
                 window?.overrideUserInterfaceStyle = .unspecified
                 #endif
             }
+
+            defaults.set(appearance, forKey: colorSchemeIntegerKey)
         }
     }
 }


### PR DESCRIPTION
Closes #10.

This PR adds a `colorSchemeIntegerKey` key to UserDefaults for an integer value. When PreferencesModel's `appearance` property is set, the new value is stored in UserDefaults.

On launch, the WriteFreelyModel sets the PreferenceModel's `appearance` property to the value saved in UserDefaults. As this forces an update to the UI, we make sure it happens on the main thread, or else this gets called before the UIWindow has been created on iOS.

This persists the user's preference for colour scheme between app launches.