### PR TITLE
Fetch collections on login, purge on logout

### DIFF
--- a/Shared/Models/PostCollection.swift
+++ b/Shared/Models/PostCollection.swift
@@ -1,8 +1,16 @@
 import Foundation
+import WriteFreely
 
-struct PostCollection: Identifiable, Hashable {
+struct PostCollection: Identifiable {
     let id = UUID()
     let title: String
+    var wfCollection: WFCollection?
+}
+
+extension PostCollection {
+    static func == (lhs: PostCollection, rhs: PostCollection) -> Bool {
+        return lhs.id == rhs.id
+    }
 }
 
 let allPostsCollection = PostCollection(title: "All Posts")

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -79,6 +79,7 @@ private extension WriteFreelyModel {
             client = nil
             DispatchQueue.main.async {
                 self.account.logout()
+                self.collections.clearUserCollection()
             }
         } catch WFError.notFound {
             // The user token is invalid or doesn't exist, so it's been invalidated by the server. Proceed with
@@ -86,6 +87,7 @@ private extension WriteFreelyModel {
             client = nil
             DispatchQueue.main.async {
                 self.account.logout()
+                self.collections.clearUserCollection()
             }
         } catch {
             // We get a 'cannot parse response' (similar to what we were seeing in the Swift package) NSURLError here,

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -18,7 +18,9 @@ struct ContentView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        ContentView()
-            .environmentObject(WriteFreelyModel())
+        let model = WriteFreelyModel()
+        model.collections = CollectionListModel(with: [userCollection1, userCollection2, userCollection3])
+        return ContentView()
+            .environmentObject(model)
     }
 }

--- a/Shared/Navigation/SidebarView.swift
+++ b/Shared/Navigation/SidebarView.swift
@@ -8,6 +8,9 @@ struct SidebarView: View {
 
 struct SidebarView_Previews: PreviewProvider {
     static var previews: some View {
-        SidebarView()
+        let model = WriteFreelyModel()
+        model.collections = CollectionListModel(with: [userCollection1, userCollection2, userCollection3])
+        return SidebarView()
+            .environmentObject(model)
     }
 }

--- a/Shared/PostCollection/CollectionListModel.swift
+++ b/Shared/PostCollection/CollectionListModel.swift
@@ -1,18 +1,13 @@
 import SwiftUI
 
-struct CollectionListModel {
+class CollectionListModel: ObservableObject {
     private(set) var userCollections: [PostCollection] = []
-    private(set) var collectionsList: [PostCollection]
+    @Published private(set) var collectionsList: [PostCollection] = [ allPostsCollection, draftsCollection ]
 
-    init() {
-        collectionsList = [ allPostsCollection, draftsCollection ]
-
-        #if DEBUG
-        userCollections = [ userCollection1, userCollection2, userCollection3 ]
-        #endif
-
+    init(with userCollections: [PostCollection]) {
         for userCollection in userCollections {
-            collectionsList.append(userCollection)
+            self.userCollections.append(userCollection)
         }
+        collectionsList.append(contentsOf: self.userCollections)
     }
 }

--- a/Shared/PostCollection/CollectionListModel.swift
+++ b/Shared/PostCollection/CollectionListModel.swift
@@ -10,4 +10,9 @@ class CollectionListModel: ObservableObject {
         }
         collectionsList.append(contentsOf: self.userCollections)
     }
+
+    func clearUserCollection() {
+        userCollections = []
+        collectionsList = [ allPostsCollection, draftsCollection ]
+    }
 }

--- a/Shared/PostCollection/CollectionListView.swift
+++ b/Shared/PostCollection/CollectionListView.swift
@@ -1,11 +1,11 @@
 import SwiftUI
 
 struct CollectionListView: View {
-    private var collections = CollectionListModel()
+    @EnvironmentObject var model: WriteFreelyModel
 
     var body: some View {
         List {
-            ForEach(collections.collectionsList) { collection in
+            ForEach(model.collections.collectionsList) { collection in
                 NavigationLink(
                     destination: PostListView(selectedCollection: collection)
                 ) {

--- a/Shared/PostCollection/CollectionListView.swift
+++ b/Shared/PostCollection/CollectionListView.swift
@@ -20,6 +20,9 @@ struct CollectionListView: View {
 
 struct CollectionSidebar_Previews: PreviewProvider {
     static var previews: some View {
-        CollectionListView()
+        let model = WriteFreelyModel()
+        model.collections = CollectionListModel(with: [userCollection1, userCollection2, userCollection3])
+        return CollectionListView()
+            .environmentObject(model)
     }
 }

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
Closes #12.

This PR adds an API call (and result handler) to the WriteFreelyModel to fetch user collections from the server, and calls it on login. The handler updates the CollectionListModel's `userCollections` property, which updates the CollectionListView.

A `clearUserCollection()` method is also added to the CollectionListModel, to purge the fetched collections when the user logs out.