### PR TITLE
Fetch posts on login, purge on logout

### DIFF
--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -30,6 +30,16 @@ class Post: Identifiable, ObservableObject {
         self.status = status
         self.collection = collection
     }
+
+    convenience init(wfPost: WFPost, in collection: PostCollection = draftsCollection) {
+        self.init(
+            title: wfPost.title ?? "",
+            body: wfPost.body,
+            createdDate: wfPost.createdDate ?? Date(),
+            status: .published,
+            collection: collection
+        )
+    }
 }
 
 #if DEBUG

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WriteFreely
 
 enum PostStatus {
     case draft
@@ -12,6 +13,7 @@ class Post: Identifiable, ObservableObject {
     @Published var createdDate: Date
     @Published var status: PostStatus
     @Published var collection: PostCollection
+    @Published var wfPost: WFPost?
 
     let id = UUID()
 

--- a/Shared/Models/PostStore.swift
+++ b/Shared/Models/PostStore.swift
@@ -10,4 +10,8 @@ struct PostStore {
     mutating func add(_ post: Post) {
         posts.append(post)
     }
+
+    mutating func purge() {
+        posts = []
+    }
 }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -73,6 +73,7 @@ private extension WriteFreelyModel {
         do {
             let user = try result.get()
             fetchUserCollections()
+            fetchUserPosts()
             saveTokenToKeychain(user.token, username: user.username, server: account.server)
             DispatchQueue.main.async {
                 self.account.login(user)
@@ -103,6 +104,7 @@ private extension WriteFreelyModel {
                 DispatchQueue.main.async {
                     self.account.logout()
                     self.collections.clearUserCollection()
+                    self.store.purge()
                 }
             } catch {
                 print("Something went wrong purging the token from the Keychain.")
@@ -117,6 +119,7 @@ private extension WriteFreelyModel {
                 DispatchQueue.main.async {
                     self.account.logout()
                     self.collections.clearUserCollection()
+                    self.store.purge()
                 }
             } catch {
                 print("Something went wrong purging the token from the Keychain.")

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -22,7 +22,7 @@ class WriteFreelyModel: ObservableObject {
         }
 
         #if DEBUG
-        for post in testPostData { store.add(post) }
+//        for post in testPostData { store.add(post) }
         #endif
 
         DispatchQueue.main.async {

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -20,6 +20,9 @@ struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         let model = WriteFreelyModel()
         model.collections = CollectionListModel(with: [userCollection1, userCollection2, userCollection3])
+        for post in testPostData {
+            model.store.add(post)
+        }
         return ContentView()
             .environmentObject(model)
     }

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -103,9 +103,13 @@ struct PostListView: View {
 
 struct PostList_Previews: PreviewProvider {
     static var previews: some View {
-        Group {
+        let model = WriteFreelyModel()
+        for post in testPostData {
+            model.store.add(post)
+        }
+        return Group {
             PostListView(selectedCollection: allPostsCollection)
-                .environmentObject(WriteFreelyModel())
+                .environmentObject(model)
         }
     }
 }


### PR DESCRIPTION
Closes #13.

⚠️ **This PR is dependent on work done in #22.** ⚠️

This PR adds an API call (and result handler) to the WriteFreelyModel to fetch user posts from the server, and calls it on login. The handler matches posts that are in a collection to the fetched collections (hence its dependency) and then adds them to the PostStore, which updates the PostListView.

A `purge()` method is also added to the PostStore, to purge the fetch posts when the user logs out.