### PR TITLE
Consolidate redundant Post properties

### DIFF
--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -30,6 +30,16 @@ class Post: Identifiable, ObservableObject {
         self.status = status
         self.collection = collection
     }
+
+    convenience init(wfPost: WFPost, in collection: PostCollection = draftsCollection) {
+        self.init(
+            title: wfPost.title ?? "",
+            body: wfPost.body,
+            createdDate: wfPost.createdDate ?? Date(),
+            status: .published,
+            collection: collection
+        )
+    }
 }
 
 #if DEBUG

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -39,6 +39,7 @@ class Post: Identifiable, ObservableObject {
             status: .published,
             collection: collection
         )
+        self.wfPost = wfPost
     }
 }
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -39,7 +39,6 @@ class Post: Identifiable, ObservableObject {
             status: .published,
             collection: collection
         )
-        self.wfPost = wfPost
     }
 }
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WriteFreely
 
 enum PostStatus {
     case draft
@@ -12,6 +13,7 @@ class Post: Identifiable, ObservableObject {
     @Published var createdDate: Date
     @Published var status: PostStatus
     @Published var collection: PostCollection
+    @Published var wfPost: WFPost?
 
     let id = UUID()
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -8,12 +8,9 @@ enum PostStatus {
 }
 
 class Post: Identifiable, ObservableObject {
-    @Published var title: String
-    @Published var body: String
-    @Published var createdDate: Date
+    @Published var wfPost: WFPost
     @Published var status: PostStatus
     @Published var collection: PostCollection
-    @Published var wfPost: WFPost?
 
     let id = UUID()
 
@@ -24,9 +21,7 @@ class Post: Identifiable, ObservableObject {
         status: PostStatus = .draft,
         collection: PostCollection = draftsCollection
     ) {
-        self.title = title
-        self.body = body
-        self.createdDate = createdDate
+        self.wfPost = WFPost(body: body, title: title, createdDate: createdDate)
         self.status = status
         self.collection = collection
     }

--- a/Shared/Models/PostStore.swift
+++ b/Shared/Models/PostStore.swift
@@ -10,4 +10,8 @@ struct PostStore {
     mutating func add(_ post: Post) {
         posts.append(post)
     }
+
+    mutating func purge() {
+        posts = []
+    }
 }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -9,7 +9,6 @@ class WriteFreelyModel: ObservableObject {
     @Published var preferences = PreferencesModel()
     @Published var store = PostStore()
     @Published var collections = CollectionListModel(with: [])
-    @Published var post: Post?
     @Published var isLoggingIn: Bool = false
 
     private var client: WFClient?

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -65,6 +65,7 @@ extension WriteFreelyModel {
 
     func publish(post: Post) {
         guard let loggedInClient = client else { return }
+
         if post.wfPost == nil {
             // This is a new local draft.
             post.wfPost = WFPost(
@@ -77,8 +78,19 @@ extension WriteFreelyModel {
             )
         } else {
             // This is an existing post.
-            // 1. Update post.wfPost properties from post properties
-            // 2. Call loggedInClient.updatePost(postId:, updatedPost:, completion: publishHandler)
+            // 1. Update Post.wfPost properties from (redundant) Post properties
+            // FIXME: https://github.com/writeas/writefreely-swiftui-multiplatform/issues/27
+            guard var publishedPost = post.wfPost else { return }
+            publishedPost.title = post.title
+            publishedPost.body = post.body
+            publishedPost.createdDate = post.createdDate
+
+            // 2. Update the post on the server and call the handler
+            loggedInClient.updatePost(
+                postId: publishedPost.postId!,
+                updatedPost: publishedPost,
+                completion: publishHandler
+            )
         }
     }
 }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -73,6 +73,7 @@ private extension WriteFreelyModel {
         do {
             let user = try result.get()
             fetchUserCollections()
+            fetchUserPosts()
             saveTokenToKeychain(user.token, username: user.username, server: account.server)
             DispatchQueue.main.async {
                 self.account.login(user)
@@ -103,6 +104,7 @@ private extension WriteFreelyModel {
                 DispatchQueue.main.async {
                     self.account.logout()
                     self.collections.clearUserCollection()
+                    self.store.purge()
                 }
             } catch {
                 print("Something went wrong purging the token from the Keychain.")
@@ -117,6 +119,7 @@ private extension WriteFreelyModel {
                 DispatchQueue.main.async {
                     self.account.logout()
                     self.collections.clearUserCollection()
+                    self.store.purge()
                 }
             } catch {
                 print("Something went wrong purging the token from the Keychain.")

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -22,7 +22,7 @@ class WriteFreelyModel: ObservableObject {
         }
 
         #if DEBUG
-        for post in testPostData { store.add(post) }
+//        for post in testPostData { store.add(post) }
         #endif
 
         DispatchQueue.main.async {

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -20,6 +20,9 @@ struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         let model = WriteFreelyModel()
         model.collections = CollectionListModel(with: [userCollection1, userCollection2, userCollection3])
+        for post in testPostData {
+            model.store.add(post)
+        }
         return ContentView()
             .environmentObject(model)
     }

--- a/Shared/PostEditor/PostEditorView.swift
+++ b/Shared/PostEditor/PostEditorView.swift
@@ -32,6 +32,7 @@ struct PostEditorView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 Button(action: {
+                    model.publish(post: post)
                     post.status = .published
                 }, label: {
                     Image(systemName: "paperplane")

--- a/Shared/PostEditor/PostEditorView.swift
+++ b/Shared/PostEditor/PostEditorView.swift
@@ -6,20 +6,21 @@ struct PostEditorView: View {
     @ObservedObject var post: Post
 
     @State private var isNewPost = false
-
+    @State private var title = ""
     var body: some View {
         VStack {
-            TextEditor(text: $post.title)
+            TextEditor(text: $title)
                 .font(.title)
                 .frame(height: 100)
-                .onChange(of: post.title) { _ in
-                    if post.status == .published {
+                .onChange(of: title) { _ in
+                    if post.status == .published && post.wfPost.title != title {
                         post.status = .edited
                     }
+                    post.wfPost.title = title
                 }
-            TextEditor(text: $post.body)
+            TextEditor(text: $post.wfPost.body)
                 .font(.body)
-                .onChange(of: post.body) { _ in
+                .onChange(of: post.wfPost.body) { _ in
                     if post.status == .published {
                         post.status = .edited
                     }
@@ -40,6 +41,7 @@ struct PostEditorView: View {
             }
         }
         .onAppear(perform: {
+            title = post.wfPost.title ?? ""
             checkIfNewPost()
             if self.isNewPost {
                 addNewPostToStore()

--- a/Shared/PostList/PostCellView.swift
+++ b/Shared/PostList/PostCellView.swift
@@ -6,10 +6,10 @@ struct PostCellView: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading) {
-                Text(post.title)
+                Text(post.wfPost.title ?? "")
                     .font(.headline)
                     .lineLimit(1)
-                Text(buildDateString(from: post.createdDate))
+                Text(buildDateString(from: post.wfPost.createdDate ?? Date()))
                     .font(.caption)
                     .lineLimit(1)
             }

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -103,9 +103,13 @@ struct PostListView: View {
 
 struct PostList_Previews: PreviewProvider {
     static var previews: some View {
-        Group {
+        let model = WriteFreelyModel()
+        for post in testPostData {
+            model.store.add(post)
+        }
+        return Group {
             PostListView(selectedCollection: allPostsCollection)
-                .environmentObject(WriteFreelyModel())
+                .environmentObject(model)
         }
     }
 }

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
Closes #27.

⚠️ **This PR is dependent on work done in #25.** ⚠️

This PR does away with several published properties in the Post type which are duplicated in its `wfPost` property.

This effectively turns the Post into a thin wrapper around the Swift package's WFPost type.