### PR TITLE
Implement reload-from-server

### DIFF
--- a/Shared/Account/AccountLogoutView.swift
+++ b/Shared/Account/AccountLogoutView.swift
@@ -7,7 +7,7 @@ struct AccountLogoutView: View {
         VStack {
             Spacer()
             VStack {
-                Text("Logged in as \(model.account.username ?? "Anonymous")")
+                Text("Logged in as \(model.account.username)")
                 Text("on \(model.account.server)")
             }
             Spacer()

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -11,6 +11,7 @@ class Post: Identifiable, ObservableObject {
     @Published var wfPost: WFPost
     @Published var status: PostStatus
     @Published var collection: PostCollection
+    @Published var hasNewerRemoteCopy: Bool = false
 
     let id = UUID()
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -35,6 +35,7 @@ class Post: Identifiable, ObservableObject {
             status: .published,
             collection: collection
         )
+        self.wfPost = wfPost
     }
 }
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -39,6 +39,7 @@ class Post: Identifiable, ObservableObject {
             status: .published,
             collection: collection
         )
+        self.wfPost = wfPost
     }
 }
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -39,7 +39,6 @@ class Post: Identifiable, ObservableObject {
             status: .published,
             collection: collection
         )
-        self.wfPost = wfPost
     }
 }
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -7,7 +7,7 @@ enum PostStatus {
     case published
 }
 
-class Post: Identifiable, ObservableObject {
+class Post: Identifiable, ObservableObject, Hashable {
     @Published var wfPost: WFPost
     @Published var status: PostStatus
     @Published var collection: PostCollection
@@ -36,6 +36,16 @@ class Post: Identifiable, ObservableObject {
             collection: collection
         )
         self.wfPost = wfPost
+    }
+}
+
+extension Post {
+    static func == (lhs: Post, rhs: Post) -> Bool {
+        return lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -11,7 +11,6 @@ class Post: Identifiable, ObservableObject {
     @Published var wfPost: WFPost
     @Published var status: PostStatus
     @Published var collection: PostCollection
-    @Published var wfPost: WFPost?
 
     let id = UUID()
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -8,12 +8,9 @@ enum PostStatus {
 }
 
 class Post: Identifiable, ObservableObject {
-    @Published var title: String
-    @Published var body: String
-    @Published var createdDate: Date
+    @Published var wfPost: WFPost
     @Published var status: PostStatus
     @Published var collection: PostCollection
-    @Published var wfPost: WFPost?
 
     let id = UUID()
 
@@ -24,9 +21,7 @@ class Post: Identifiable, ObservableObject {
         status: PostStatus = .draft,
         collection: PostCollection = draftsCollection
     ) {
-        self.title = title
-        self.body = body
-        self.createdDate = createdDate
+        self.wfPost = WFPost(body: body, title: title, createdDate: createdDate)
         self.status = status
         self.collection = collection
     }

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -35,7 +35,6 @@ class Post: Identifiable, ObservableObject {
             status: .published,
             collection: collection
         )
-        self.wfPost = wfPost
     }
 }
 

--- a/Shared/Models/Post.swift
+++ b/Shared/Models/Post.swift
@@ -11,6 +11,7 @@ class Post: Identifiable, ObservableObject {
     @Published var wfPost: WFPost
     @Published var status: PostStatus
     @Published var collection: PostCollection
+    @Published var wfPost: WFPost?
 
     let id = UUID()
 

--- a/Shared/Models/PostStore.swift
+++ b/Shared/Models/PostStore.swift
@@ -14,8 +14,4 @@ struct PostStore {
     mutating func purgeAllPosts() {
         posts = []
     }
-
-    mutating func purgeRemotePosts() {
-        posts = posts.filter { $0.wfPost.postId == nil }
-    }
 }

--- a/Shared/Models/PostStore.swift
+++ b/Shared/Models/PostStore.swift
@@ -11,7 +11,11 @@ struct PostStore {
         posts.append(post)
     }
 
-    mutating func purge() {
+    mutating func purgeAllPosts() {
         posts = []
+    }
+
+    mutating func purgeRemotePosts() {
+        posts = posts.filter { $0.wfPost.postId == nil }
     }
 }

--- a/Shared/Models/PostStore.swift
+++ b/Shared/Models/PostStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WriteFreely
 
 struct PostStore {
     var posts: [Post]
@@ -23,7 +24,23 @@ struct PostStore {
         if let localCopy = localCopy {
             localCopy.wfPost.updatedDate = Date()
         } else {
-            print("local copy not found")
+            print("Error: Local copy not found")
+        }
+    }
+
+    mutating func replace(post: Post, with fetchedPost: WFPost) {
+        // Find the local copy in the store.
+        let localCopy = posts.first(where: { $0.id == post.id })
+
+        // Replace the local copy's wfPost property with the fetched copy.
+        if let localCopy = localCopy {
+            localCopy.wfPost = fetchedPost
+            DispatchQueue.main.async {
+                localCopy.hasNewerRemoteCopy = false
+                localCopy.status = .published
+            }
+        } else {
+            print("Error: Local copy not found")
         }
     }
 

--- a/Shared/Models/PostStore.swift
+++ b/Shared/Models/PostStore.swift
@@ -14,4 +14,15 @@ struct PostStore {
     mutating func purgeAllPosts() {
         posts = []
     }
-}
+
+    mutating func update(_ post: Post) {
+        // Find the local copy in the store
+        let localCopy = posts.first(where: { $0.id == post.id })
+
+        // If there's a local copy, update the updatedDate property of its WFPost
+        if let localCopy = localCopy {
+            localCopy.wfPost.updatedDate = Date()
+        } else {
+            print("local copy not found")
+        }
+    }

--- a/Shared/Models/PostStore.swift
+++ b/Shared/Models/PostStore.swift
@@ -26,3 +26,24 @@ struct PostStore {
             print("local copy not found")
         }
     }
+
+    mutating func updateStore(with fetchedPosts: [Post]) {
+        for fetchedPost in fetchedPosts {
+            // Find the local copy in the store.
+            let localCopy = posts.first(where: { $0.wfPost.postId == fetchedPost.wfPost.postId })
+
+            // If there's a local copy, check which is newer; if not, add the fetched post to the store.
+            if let localCopy = localCopy {
+                // We do not discard the local copy; we simply set the hasNewerRemoteCopy flag accordingly.
+                if let remoteCopyUpdatedDate = fetchedPost.wfPost.updatedDate,
+                   let localCopyUpdatedDate = localCopy.wfPost.updatedDate {
+                    localCopy.hasNewerRemoteCopy = remoteCopyUpdatedDate > localCopyUpdatedDate
+                } else {
+                    print("Error: could not determine which copy of post is newer")
+                }
+            } else {
+                add(fetchedPost)
+            }
+        }
+    }
+}

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -9,7 +9,6 @@ class WriteFreelyModel: ObservableObject {
     @Published var preferences = PreferencesModel()
     @Published var store = PostStore()
     @Published var collections = CollectionListModel(with: [])
-    @Published var post: Post?
     @Published var isLoggingIn: Bool = false
 
     private var client: WFClient?

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -65,6 +65,7 @@ extension WriteFreelyModel {
 
     func publish(post: Post) {
         guard let loggedInClient = client else { return }
+
         if post.wfPost == nil {
             // This is a new local draft.
             post.wfPost = WFPost(
@@ -77,8 +78,19 @@ extension WriteFreelyModel {
             )
         } else {
             // This is an existing post.
-            // 1. Update post.wfPost properties from post properties
-            // 2. Call loggedInClient.updatePost(postId:, updatedPost:, completion: publishHandler)
+            // 1. Update Post.wfPost properties from (redundant) Post properties
+            // FIXME: https://github.com/writeas/writefreely-swiftui-multiplatform/issues/27
+            guard var publishedPost = post.wfPost else { return }
+            publishedPost.title = post.title
+            publishedPost.body = post.body
+            publishedPost.createdDate = post.createdDate
+
+            // 2. Update the post on the server and call the handler
+            loggedInClient.updatePost(
+                postId: publishedPost.postId!,
+                updatedPost: publishedPost,
+                completion: publishHandler
+            )
         }
     }
 }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -100,6 +100,15 @@ extension WriteFreelyModel {
             )
         }
     }
+
+    func updateFromServer(post: Post) {
+        guard let loggedInClient = client else { return }
+        guard let postId = post.wfPost.postId else { return }
+        DispatchQueue.main.async {
+            self.selectedPost = post
+        }
+        loggedInClient.getPost(byId: postId, completion: updateFromServerHandler)
+    }
 }
 
 private extension WriteFreelyModel {
@@ -208,9 +217,6 @@ private extension WriteFreelyModel {
                     post = Post(wfPost: fetchedPost)
                 }
                 fetchedPostsArray.append(post)
-//                DispatchQueue.main.async {
-//                    self.store.add(post)
-//                }
             }
             DispatchQueue.main.async {
                 self.store.updateStore(with: fetchedPostsArray)
@@ -229,6 +235,18 @@ private extension WriteFreelyModel {
             guard let index = foundPostIndex else { return }
             DispatchQueue.main.async {
                 self.store.posts[index].wfPost = wfPost
+            }
+        } catch {
+            print(error)
+        }
+    }
+
+    func updateFromServerHandler(result: Result<WFPost, Error>) {
+        do {
+            let fetchedPost = try result.get()
+            DispatchQueue.main.async {
+                guard let selectedPost = self.selectedPost else { return }
+                self.store.replace(post: selectedPost, with: fetchedPost)
             }
         } catch {
             print(error)

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -26,6 +26,22 @@ class WriteFreelyModel: ObservableObject {
 
         DispatchQueue.main.async {
             self.account.restoreState()
+            if self.account.isLoggedIn {
+                guard let serverURL = URL(string: self.account.server) else {
+                    print("Server URL not found")
+                    return
+                }
+                guard let token = self.fetchTokenFromKeychain(
+                        username: self.account.username,
+                        server: self.account.server
+                ) else {
+                    print("Could not fetch token from Keychain")
+                    return
+                }
+                self.account.login(WFUser(token: token, username: self.account.username))
+                self.client = WFClient(for: serverURL)
+                self.client?.user = self.account.user
+            }
         }
     }
 }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -176,6 +176,7 @@ private extension WriteFreelyModel {
     func fetchUserPostsHandler(result: Result<[WFPost], Error>) {
         do {
             let fetchedPosts = try result.get()
+            var fetchedPostsArray: [Post] = []
             for fetchedPost in fetchedPosts {
                 var post: Post
                 if let matchingAlias = fetchedPost.collectionAlias {
@@ -186,9 +187,13 @@ private extension WriteFreelyModel {
                 } else {
                     post = Post(wfPost: fetchedPost)
                 }
-                DispatchQueue.main.async {
-                    self.store.add(post)
-                }
+                fetchedPostsArray.append(post)
+//                DispatchQueue.main.async {
+//                    self.store.add(post)
+//                }
+            }
+            DispatchQueue.main.async {
+                self.store.updateStore(with: fetchedPostsArray)
             }
         } catch {
             print(error)

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -121,7 +121,7 @@ private extension WriteFreelyModel {
                 DispatchQueue.main.async {
                     self.account.logout()
                     self.collections.clearUserCollection()
-                    self.store.purge()
+                    self.store.purgeAllPosts()
                 }
             } catch {
                 print("Something went wrong purging the token from the Keychain.")
@@ -136,7 +136,7 @@ private extension WriteFreelyModel {
                 DispatchQueue.main.async {
                     self.account.logout()
                     self.collections.clearUserCollection()
-                    self.store.purge()
+                    self.store.purgeAllPosts()
                 }
             } catch {
                 print("Something went wrong purging the token from the Keychain.")

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -42,6 +42,9 @@ class WriteFreelyModel: ObservableObject {
                 self.account.login(WFUser(token: token, username: self.account.username))
                 self.client = WFClient(for: serverURL)
                 self.client?.user = self.account.user
+                self.collections.clearUserCollection()
+                self.fetchUserCollections()
+                self.fetchUserPosts()
             }
         }
     }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -10,6 +10,7 @@ class WriteFreelyModel: ObservableObject {
     @Published var store = PostStore()
     @Published var collections = CollectionListModel(with: [])
     @Published var isLoggingIn: Bool = false
+    @Published var selectedPost: Post?
 
     private var client: WFClient?
     private let defaults = UserDefaults.standard

--- a/Shared/PostEditor/PostEditorStatusToolbarView.swift
+++ b/Shared/PostEditor/PostEditorStatusToolbarView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+struct PostEditorStatusToolbarView: View {
+    #if os(iOS)
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    #endif
+    @EnvironmentObject var model: WriteFreelyModel
+
+    @ObservedObject var post: Post
+
+    var body: some View {
+        if post.hasNewerRemoteCopy {
+            #if os(iOS)
+            if horizontalSizeClass == .compact {
+                VStack {
+                    PostStatusBadgeView(post: post)
+                    HStack {
+                        Text("⚠️ Newer copy on server. Replace local copy?")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        Button(action: {
+                            model.updateFromServer(post: post)
+                        }, label: {
+                            Image(systemName: "square.and.arrow.down")
+                        })
+                    }
+                    .padding(.bottom)
+                }
+                .padding(.top)
+            } else {
+                HStack {
+                    PostStatusBadgeView(post: post)
+                        .padding(.trailing)
+                    Text("⚠️ Newer copy on server. Replace local copy?")
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                    Button(action: {
+                        model.updateFromServer(post: post)
+                    }, label: {
+                        Image(systemName: "square.and.arrow.down")
+                    })
+                }
+            }
+            #else
+            HStack {
+                PostStatusBadgeView(post: post)
+                    .padding(.trailing)
+                Text("⚠️ Newer copy on server. Replace local copy?")
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+                Button(action: {
+                    model.updateFromServer(post: post)
+                }, label: {
+                    Image(systemName: "square.and.arrow.down")
+                })
+            }
+            #endif
+        } else {
+            PostStatusBadgeView(post: post)
+        }
+    }
+}
+
+struct ToolbarView_LocalPreviews: PreviewProvider {
+    static var previews: some View {
+        let model = WriteFreelyModel()
+        let post = testPost
+        return PostEditorStatusToolbarView(post: post)
+            .environmentObject(model)
+    }
+}
+
+struct ToolbarView_RemotePreviews: PreviewProvider {
+    static var previews: some View {
+        let model = WriteFreelyModel()
+        let newerRemotePost = Post(
+            title: testPost.wfPost.title ?? "",
+            body: testPost.wfPost.body,
+            createdDate: testPost.wfPost.createdDate ?? Date(),
+            status: testPost.status,
+            collection: testPost.collection
+        )
+        newerRemotePost.hasNewerRemoteCopy = true
+        return PostEditorStatusToolbarView(post: newerRemotePost)
+            .environmentObject(model)
+    }
+}
+
+#if os(iOS)
+struct ToolbarView_CompactLocalPreviews: PreviewProvider {
+    static var previews: some View {
+        let model = WriteFreelyModel()
+        let post = testPost
+        return PostEditorStatusToolbarView(post: post)
+            .environmentObject(model)
+            .environment(\.horizontalSizeClass, .compact)
+    }
+}
+#endif
+
+#if os(iOS)
+struct ToolbarView_CompactRemotePreviews: PreviewProvider {
+    static var previews: some View {
+        let model = WriteFreelyModel()
+        let newerRemotePost = Post(
+            title: testPost.wfPost.title ?? "",
+            body: testPost.wfPost.body,
+            createdDate: testPost.wfPost.createdDate ?? Date(),
+            status: testPost.status,
+            collection: testPost.collection
+        )
+        newerRemotePost.hasNewerRemoteCopy = true
+        return PostEditorStatusToolbarView(post: newerRemotePost)
+            .environmentObject(model)
+            .environment(\.horizontalSizeClass, .compact)
+    }
+}
+#endif

--- a/Shared/PostEditor/PostEditorView.swift
+++ b/Shared/PostEditor/PostEditorView.swift
@@ -32,6 +32,7 @@ struct PostEditorView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 Button(action: {
+                    model.publish(post: post)
                     post.status = .published
                 }, label: {
                     Image(systemName: "paperplane")

--- a/Shared/PostEditor/PostEditorView.swift
+++ b/Shared/PostEditor/PostEditorView.swift
@@ -48,7 +48,11 @@ struct PostEditorView: View {
             }
         })
         .onDisappear(perform: {
-            post.wfPost.updatedDate = Date()
+            if post.status == .edited {
+                DispatchQueue.main.async {
+                    model.store.update(post)
+                }
+            }
         })
     }
 

--- a/Shared/PostEditor/PostEditorView.swift
+++ b/Shared/PostEditor/PostEditorView.swift
@@ -6,20 +6,21 @@ struct PostEditorView: View {
     @ObservedObject var post: Post
 
     @State private var isNewPost = false
-
+    @State private var title = ""
     var body: some View {
         VStack {
-            TextEditor(text: $post.title)
+            TextEditor(text: $title)
                 .font(.title)
                 .frame(height: 100)
-                .onChange(of: post.title) { _ in
-                    if post.status == .published {
+                .onChange(of: title) { _ in
+                    if post.status == .published && post.wfPost.title != title {
                         post.status = .edited
                     }
+                    post.wfPost.title = title
                 }
-            TextEditor(text: $post.body)
+            TextEditor(text: $post.wfPost.body)
                 .font(.body)
-                .onChange(of: post.body) { _ in
+                .onChange(of: post.wfPost.body) { _ in
                     if post.status == .published {
                         post.status = .edited
                     }
@@ -40,6 +41,7 @@ struct PostEditorView: View {
             }
         }
         .onAppear(perform: {
+            title = post.wfPost.title ?? ""
             checkIfNewPost()
             if self.isNewPost {
                 addNewPostToStore()

--- a/Shared/PostEditor/PostEditorView.swift
+++ b/Shared/PostEditor/PostEditorView.swift
@@ -47,6 +47,9 @@ struct PostEditorView: View {
                 addNewPostToStore()
             }
         })
+        .onDisappear(perform: {
+            post.wfPost.updatedDate = Date()
+        })
     }
 
     private func checkIfNewPost() {

--- a/Shared/PostEditor/PostEditorView.swift
+++ b/Shared/PostEditor/PostEditorView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct PostEditorView: View {
-    @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @EnvironmentObject var model: WriteFreelyModel
 
     @ObservedObject var post: Post
@@ -30,40 +29,7 @@ struct PostEditorView: View {
         .padding()
         .toolbar {
             ToolbarItem(placement: .status) {
-                if post.hasNewerRemoteCopy {
-                    if horizontalSizeClass == .compact {
-                        VStack {
-                            PostStatusBadgeView(post: post)
-                            HStack {
-                                Text("⚠️ Newer copy on server. Replace local copy?")
-                                    .font(.caption)
-                                    .foregroundColor(.secondary)
-                                Button(action: {
-                                    model.updateFromServer(post: post)
-                                }, label: {
-                                    Image(systemName: "square.and.arrow.down")
-                                })
-                            }
-                            .padding(.bottom)
-                        }
-                        .padding(.top)
-                    } else {
-                        HStack {
-                            PostStatusBadgeView(post: post)
-                                .padding(.trailing)
-                            Text("⚠️ Newer copy on server. Replace local copy?")
-                                .font(.callout)
-                                .foregroundColor(.secondary)
-                            Button(action: {
-                                model.updateFromServer(post: post)
-                            }, label: {
-                                Image(systemName: "square.and.arrow.down")
-                            })
-                        }
-                    }
-                } else {
-                    PostStatusBadgeView(post: post)
-                }
+                PostEditorStatusToolbarView(post: post)
             }
             ToolbarItem(placement: .primaryAction) {
                 Button(action: {

--- a/Shared/PostEditor/PostEditorView.swift
+++ b/Shared/PostEditor/PostEditorView.swift
@@ -9,6 +9,10 @@ struct PostEditorView: View {
     @State private var title = ""
     var body: some View {
         VStack {
+            if post.hasNewerRemoteCopy {
+                Text("⚠️ Newer copy on server")
+                    .font(.callout)
+            }
             TextEditor(text: $title)
                 .font(.title)
                 .frame(height: 100)

--- a/Shared/PostList/PostCellView.swift
+++ b/Shared/PostList/PostCellView.swift
@@ -6,10 +6,10 @@ struct PostCellView: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading) {
-                Text(post.title)
+                Text(post.wfPost.title ?? "")
                     .font(.headline)
                     .lineLimit(1)
-                Text(buildDateString(from: post.createdDate))
+                Text(buildDateString(from: post.wfPost.createdDate ?? Date()))
                     .font(.caption)
                     .lineLimit(1)
             }

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -145,7 +145,6 @@ struct PostListView: View {
 
     private func reloadFromServer() {
         DispatchQueue.main.async {
-            model.store.purgeRemotePosts()
             model.collections.clearUserCollection()
             model.fetchUserCollections()
             model.fetchUserPosts()

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct PostListView: View {
     @EnvironmentObject var model: WriteFreelyModel
     @State var selectedCollection: PostCollection
-    @State private var isPresentingRefreshWarning = false
 
     #if os(iOS)
     @State private var isPresentingSettings = false
@@ -55,24 +54,9 @@ struct PostListView: View {
                             .foregroundColor(.secondary)
                         Spacer()
                         Button(action: {
-                            isPresentingRefreshWarning = true
+                            reloadFromServer()
                         }, label: {
                             Image(systemName: "arrow.clockwise")
-                        })
-                        .actionSheet(isPresented: $isPresentingRefreshWarning, content: {
-                            ActionSheet(
-                                title: Text("Are you sure you want to reload content from the server?"),
-                                message: Text("""
-                        Content on your device will be replaced by content from the server and any unpublished changes \
-                        will be lost, except for local drafts.
-
-                        You can't undo this action.
-                        """),
-                                buttons: [
-                                    .cancel(),
-                                    .destructive(Text("Reload From Server"), action: reloadFromServer)
-                                ]
-                            )
                         })
                         .disabled(!model.account.isLoggedIn)
                     }
@@ -103,22 +87,9 @@ struct PostListView: View {
                 Image(systemName: "square.and.pencil")
             })
             Button(action: {
-                isPresentingRefreshWarning = true
+                reloadFromServer()
             }, label: {
                 Image(systemName: "arrow.clockwise")
-            })
-            .alert(isPresented: $isPresentingRefreshWarning, content: {
-                Alert(
-                    title: Text("Are you sure you want to reload content from the server?"),
-                    message: Text("""
-                        Content on your Mac will be replaced by content from the server and any unpublished changes \
-                        will be lost, except for local drafts.
-
-                        You can't undo this action.
-                        """),
-                    primaryButton: .cancel(),
-                    secondaryButton: .destructive(Text("Reload From Server"), action: reloadFromServer)
-                )
             })
             .disabled(!model.account.isLoggedIn)
         }

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -49,9 +49,32 @@ struct PostListView: View {
                                 SettingsView(isPresented: $isPresentingSettings)
                             }
                         )
+                        .padding(.leading)
                         Spacer()
                         Text(pluralizedPostCount(for: showPosts(for: selectedCollection)))
                             .foregroundColor(.secondary)
+                        Spacer()
+                        Button(action: {
+                            isPresentingRefreshWarning = true
+                        }, label: {
+                            Image(systemName: "arrow.clockwise")
+                        })
+                        .actionSheet(isPresented: $isPresentingRefreshWarning, content: {
+                            ActionSheet(
+                                title: Text("Are you sure you want to reload content from the server?"),
+                                message: Text("""
+                        Content on your device will be replaced by content from the server and any unpublished changes \
+                        will be lost, except for local drafts.
+
+                        You can't undo this action.
+                        """),
+                                buttons: [
+                                    .cancel(),
+                                    .destructive(Text("Reload From Server"), action: reloadFromServer)
+                                ]
+                            )
+                        })
+                        .disabled(!model.account.isLoggedIn)
                     }
                     .padding()
                     .frame(width: geometry.size.width)

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		1756AE7A24CB65DF00FD7257 /* PostListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756AE7924CB65DF00FD7257 /* PostListView.swift */; };
 		1756AE7B24CB65DF00FD7257 /* PostListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756AE7924CB65DF00FD7257 /* PostListView.swift */; };
 		1756AE8124CB844500FD7257 /* View+Keyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756AE8024CB844500FD7257 /* View+Keyboard.swift */; };
+		1756DBB324FECDBB00207AB8 /* PostEditorStatusToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756DBB224FECDBB00207AB8 /* PostEditorStatusToolbarView.swift */; };
+		1756DBB424FECDBB00207AB8 /* PostEditorStatusToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756DBB224FECDBB00207AB8 /* PostEditorStatusToolbarView.swift */; };
 		1762DCB324EB086C0019C4EB /* CollectionListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1762DCB224EB086C0019C4EB /* CollectionListModel.swift */; };
 		1762DCB424EB086C0019C4EB /* CollectionListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1762DCB224EB086C0019C4EB /* CollectionListModel.swift */; };
 		1765F62A24E18EA200C9EBF0 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1765F62924E18EA200C9EBF0 /* SidebarView.swift */; };
@@ -90,6 +92,7 @@
 		1756AE7624CB2EDD00FD7257 /* PostEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorView.swift; sourceTree = "<group>"; };
 		1756AE7924CB65DF00FD7257 /* PostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListView.swift; sourceTree = "<group>"; };
 		1756AE8024CB844500FD7257 /* View+Keyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Keyboard.swift"; sourceTree = "<group>"; };
+		1756DBB224FECDBB00207AB8 /* PostEditorStatusToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorStatusToolbarView.swift; sourceTree = "<group>"; };
 		1762DCB224EB086C0019C4EB /* CollectionListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionListModel.swift; sourceTree = "<group>"; };
 		1765F62924E18EA200C9EBF0 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		17A5388724DDA31F00DEFF9A /* MacAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAccountView.swift; sourceTree = "<group>"; };
@@ -166,6 +169,7 @@
 			isa = PBXGroup;
 			children = (
 				1756AE7624CB2EDD00FD7257 /* PostEditorView.swift */,
+				1756DBB224FECDBB00207AB8 /* PostEditorStatusToolbarView.swift */,
 			);
 			path = PostEditor;
 			sourceTree = "<group>";
@@ -546,6 +550,7 @@
 				17120DAC24E1B99F002B9F6C /* AccountLoginView.swift in Sources */,
 				17120DA924E1B2F5002B9F6C /* AccountLogoutView.swift in Sources */,
 				171BFDFA24D4AF8300888236 /* CollectionListView.swift in Sources */,
+				1756DBB324FECDBB00207AB8 /* PostEditorStatusToolbarView.swift in Sources */,
 				17120DB224E1E19C002B9F6C /* SettingsHeaderView.swift in Sources */,
 				1756AE7724CB2EDD00FD7257 /* PostEditorView.swift in Sources */,
 				17DF32D524C8CA3400BCE2E3 /* PostStatusBadgeView.swift in Sources */,
@@ -587,6 +592,7 @@
 				1762DCB424EB086C0019C4EB /* CollectionListModel.swift in Sources */,
 				17A5389324DDED0000DEFF9A /* PreferencesView.swift in Sources */,
 				1756AE6F24CB255B00FD7257 /* PostStore.swift in Sources */,
+				1756DBB424FECDBB00207AB8 /* PostEditorStatusToolbarView.swift in Sources */,
 				1756AE6C24CB1E4B00FD7257 /* Post.swift in Sources */,
 				17A5388F24DDEC7400DEFF9A /* AccountView.swift in Sources */,
 				1756AE7524CB26FA00FD7257 /* PostCellView.swift in Sources */,

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
Closes #19.

⚠️ **This PR is dependent on work done in #28.** ⚠️

This PR implements a naïve first pass at refreshing on-device content from the server, using the following interaction design:

1. When logged in, enable a reload button on the post list.
2. When the reload button is activated, warn the user that their unpublished changes will be lost if they continue.
3. If the user confirms that they want to proceed, purge everything but their local drafts, and fetch all content back from the server.

This PR aims to be sufficient for the MVP, and therefore defines the server version of a post as the canonical copy. This assumption may not be suitable for all cases (e.g., users with very large number of posts that must be reloaded).