### PR TITLE
Move sheet modifier for SettingsView outside of NavigationView

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -11,6 +11,10 @@ class WriteFreelyModel: ObservableObject {
     @Published var isLoggingIn: Bool = false
     @Published var selectedPost: WFAPost?
 
+    #if os(iOS)
+    @Published var isPresentingSettingsView: Bool = false
+    #endif
+
     private var client: WFClient?
     private let defaults = UserDefaults.standard
 

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -13,6 +13,18 @@ struct ContentView: View {
                 .foregroundColor(.secondary)
         }
         .environmentObject(model)
+
+        #if os(iOS)
+        EmptyView()
+            .sheet(
+                isPresented: $model.isPresentingSettingsView,
+                onDismiss: { model.isPresentingSettingsView = false },
+                content: {
+                    SettingsView()
+                        .environmentObject(model)
+                }
+            )
+        #endif
     }
 }
 

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -7,10 +7,6 @@ struct PostListView: View {
     @State var selectedCollection: WFACollection?
     @State var showAllPosts: Bool = false
 
-    #if os(iOS)
-    @State private var isPresentingSettings = false
-    #endif
-
     var body: some View {
         #if os(iOS)
         GeometryReader { geometry in
@@ -31,18 +27,10 @@ struct PostListView: View {
                 ToolbarItem(placement: .bottomBar) {
                     HStack {
                         Button(action: {
-                            isPresentingSettings = true
+                            model.isPresentingSettingsView = true
                         }, label: {
                             Image(systemName: "gear")
-                        }).sheet(
-                            isPresented: $isPresentingSettings,
-                            onDismiss: {
-                                isPresentingSettings = false
-                            },
-                            content: {
-                                SettingsView(isPresented: $isPresentingSettings)
-                            }
-                        )
+                        })
                         .padding(.leading)
                         Spacer()
                         Text(pluralizedPostCount(for: showPosts(for: selectedCollection)))

--- a/iOS/Settings/SettingsHeaderView.swift
+++ b/iOS/Settings/SettingsHeaderView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct SettingsHeaderView: View {
-    @Binding var isPresented: Bool
+    @Environment(\.presentationMode) var presentationMode
 
     var body: some View {
         HStack {
@@ -10,7 +10,7 @@ struct SettingsHeaderView: View {
                 .fontWeight(.bold)
             Spacer()
             Button(action: {
-                isPresented = false
+                presentationMode.wrappedValue.dismiss()
             }, label: {
                 Image(systemName: "xmark.circle")
             })
@@ -21,6 +21,6 @@ struct SettingsHeaderView: View {
 
 struct SettingsHeaderView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsHeaderView(isPresented: .constant(true))
+        SettingsHeaderView()
     }
 }

--- a/iOS/Settings/SettingsView.swift
+++ b/iOS/Settings/SettingsView.swift
@@ -3,11 +3,9 @@ import SwiftUI
 struct SettingsView: View {
     @EnvironmentObject var model: WriteFreelyModel
 
-    @Binding var isPresented: Bool
-
     var body: some View {
         VStack {
-            SettingsHeaderView(isPresented: $isPresented)
+            SettingsHeaderView()
             Form {
                 Section(header: Text("Login Details")) {
                     AccountView()
@@ -23,7 +21,7 @@ struct SettingsView: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView(isPresented: .constant(true))
+        SettingsView()
             .environmentObject(WriteFreelyModel())
     }
 }


### PR DESCRIPTION
Closes #23.

⚠️ **Please note that this PR depends on work done in PR #47** ⚠️

It turns out that if you use a `.sheet()` modifier to open a SwiftUI view somewhere within a NavigationView, things will act oddly. Moving it outside of the NavigationView solves the issue.