### PR TITLE
Show editor on launch

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -57,6 +57,32 @@ class WriteFreelyModel: ObservableObject {
                 self.fetchUserCollections()
                 self.fetchUserPosts()
             }
+
+            if let lastDraft = self.editor.fetchLastDraft() {
+                self.selectedPost = lastDraft
+            } else {
+                let managedPost = WFAPost(context: LocalStorageManager.persistentContainer.viewContext)
+                managedPost.createdDate = Date()
+                managedPost.title = ""
+                managedPost.body = ""
+                managedPost.status = PostStatus.local.rawValue
+                switch self.preferences.font {
+                case 1:
+                    managedPost.appearance = "sans"
+                case 2:
+                    managedPost.appearance = "wrap"
+                default:
+                    managedPost.appearance = "serif"
+                }
+                if let languageCode = Locale.current.languageCode {
+                    managedPost.language = languageCode
+                    managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
+                }
+                DispatchQueue.main.async {
+                    LocalStorageManager().saveContext()
+                }
+                self.selectedPost = managedPost
+            }
         }
 
         monitor.pathUpdateHandler = { path in

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -15,7 +15,11 @@ class WriteFreelyModel: ObservableObject {
     @Published var selectedPost: WFAPost? {
         didSet {
             if let post = selectedPost {
-                if post.status != PostStatus.published.rawValue { editor.setLastDraft(post) }
+                if post.status != PostStatus.published.rawValue {
+                    editor.setLastDraft(post)
+                } else {
+                    editor.clearLastDraft()
+                }
             } else {
                 editor.clearLastDraft()
             }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -61,34 +61,6 @@ class WriteFreelyModel: ObservableObject {
                 self.fetchUserCollections()
                 self.fetchUserPosts()
             }
-
-            if let lastDraft = self.editor.fetchLastDraft() {
-                DispatchQueue.main.async {
-                    self.selectedPost = lastDraft
-                }
-            } else {
-                let managedPost = WFAPost(context: LocalStorageManager.persistentContainer.viewContext)
-                managedPost.createdDate = Date()
-                managedPost.title = ""
-                managedPost.body = ""
-                managedPost.status = PostStatus.local.rawValue
-                switch self.preferences.font {
-                case 1:
-                    managedPost.appearance = "sans"
-                case 2:
-                    managedPost.appearance = "wrap"
-                default:
-                    managedPost.appearance = "serif"
-                }
-                if let languageCode = Locale.current.languageCode {
-                    managedPost.language = languageCode
-                    managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
-                }
-                DispatchQueue.main.async {
-                    LocalStorageManager().saveContext()
-                    self.selectedPost = managedPost
-                }
-            }
         }
 
         monitor.pathUpdateHandler = { path in

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -59,7 +59,9 @@ class WriteFreelyModel: ObservableObject {
             }
 
             if let lastDraft = self.editor.fetchLastDraft() {
-                self.selectedPost = lastDraft
+                DispatchQueue.main.async {
+                    self.selectedPost = lastDraft
+                }
             } else {
                 let managedPost = WFAPost(context: LocalStorageManager.persistentContainer.viewContext)
                 managedPost.createdDate = Date()
@@ -80,8 +82,8 @@ class WriteFreelyModel: ObservableObject {
                 }
                 DispatchQueue.main.async {
                     LocalStorageManager().saveContext()
+                    self.selectedPost = managedPost
                 }
-                self.selectedPost = managedPost
             }
         }
 

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -9,9 +9,18 @@ class WriteFreelyModel: ObservableObject {
     @Published var account = AccountModel()
     @Published var preferences = PreferencesModel()
     @Published var posts = PostListModel()
+    @Published var editor = PostEditorModel()
     @Published var isLoggingIn: Bool = false
     @Published var hasNetworkConnection: Bool = false
-    @Published var selectedPost: WFAPost?
+    @Published var selectedPost: WFAPost? {
+        didSet {
+            if let post = selectedPost {
+                if post.status != PostStatus.published.rawValue { editor.setLastDraft(post) }
+            } else {
+                editor.clearLastDraft()
+            }
+        }
+    }
     @Published var isPresentingDeleteAlert: Bool = false
     @Published var postToDelete: WFAPost?
     #if os(iOS)

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -12,6 +12,30 @@ struct ContentView: View {
             Text("Select a post, or create a new local draft.")
                 .foregroundColor(.secondary)
         }
+        .onAppear(perform: {
+            if let lastDraft = self.model.editor.fetchLastDraft() {
+                model.selectedPost = lastDraft
+            } else {
+                let managedPost = WFAPost(context: LocalStorageManager.persistentContainer.viewContext)
+                managedPost.createdDate = Date()
+                managedPost.title = ""
+                managedPost.body = ""
+                managedPost.status = PostStatus.local.rawValue
+                switch self.model.preferences.font {
+                case 1:
+                    managedPost.appearance = "sans"
+                case 2:
+                    managedPost.appearance = "wrap"
+                default:
+                    managedPost.appearance = "serif"
+                }
+                if let languageCode = Locale.current.languageCode {
+                    managedPost.language = languageCode
+                    managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
+                }
+                model.selectedPost = managedPost
+            }
+        })
         .environmentObject(model)
         .alert(isPresented: $model.isPresentingDeleteAlert) {
             Alert(

--- a/Shared/PostEditor/PostEditorModel.swift
+++ b/Shared/PostEditor/PostEditorModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+import CoreData
+
+struct PostEditorModel {
+    let lastDraftObjectURLKey = "lastDraftObjectURLKey"
+    private(set) var lastDraft: WFAPost?
+
+    mutating func setLastDraft(_ post: WFAPost) {
+        lastDraft = post
+        UserDefaults.standard.set(post.objectID.uriRepresentation(), forKey: lastDraftObjectURLKey)
+    }
+
+    mutating func fetchLastDraft() -> WFAPost? {
+        let coordinator = LocalStorageManager.persistentContainer.persistentStoreCoordinator
+
+        // See if we have a lastDraftObjectURI
+        guard let lastDraftObjectURI = UserDefaults.standard.url(forKey: lastDraftObjectURLKey) else { return nil }
+
+        // See if we can get an ObjectID from the URI representation
+        guard let lastDraftObjectID = coordinator.managedObjectID(forURIRepresentation: lastDraftObjectURI) else {
+            return nil
+        }
+
+        lastDraft = LocalStorageManager.persistentContainer.viewContext.object(with: lastDraftObjectID) as? WFAPost
+        return lastDraft
+    }
+
+    mutating func clearLastDraft() {
+        lastDraft = nil
+        UserDefaults.standard.removeObject(forKey: lastDraftObjectURLKey)
+    }
+}

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -121,8 +121,8 @@ struct PostListView: View {
         }
         DispatchQueue.main.async {
             LocalStorageManager().saveContext()
+            model.selectedPost = managedPost
         }
-        model.selectedPost = managedPost
     }
 }
 

--- a/Technotes/EditorLaunchingPolicy.md
+++ b/Technotes/EditorLaunchingPolicy.md
@@ -1,0 +1,21 @@
+#  Editor Launching Policy
+
+_Last updated: Wednesday, 23 September, 2020_
+
+This technote defines the policy for what is loaded in the post editor on app launch.
+
+The app shall always launch to the post editor. Determining what post should be loaded in the editor requires defining the following:
+
+- **Last Draft:** The last post with either a `local` or `edited` status to have been loaded into the post editor. It's important to note that a 
+`published` post that is loaded into the post editor and is then changed becomes an `edited` post, and therefore qualifies as a last draft.
+
+The launch policy is as follows:
+
+The app shall launch to the last draft, _except_ when:
+
+- There is no last draft (i.e., on the first launch of the app); or
+- The user's actions signal that they are done working with this last draft:
+    - The last draft was `published` before quitting the app
+    - The user's last action in the app was to leave the post editor (iOS) or deselect any post from the post list (macOS).
+ 
+In these cases, the app shall launch to a new, blank, `local` post.

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1709ADDF251B9A110053AF79 /* EditorLaunchingPolicy.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = EditorLaunchingPolicy.md; sourceTree = "<group>"; };
 		17120DA424E19CBF002B9F6C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		17120DA824E1B2F5002B9F6C /* AccountLogoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLogoutView.swift; sourceTree = "<group>"; };
 		17120DAB24E1B99F002B9F6C /* AccountLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLoginView.swift; sourceTree = "<group>"; };
@@ -193,6 +194,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1709ADDE251B99D40053AF79 /* Technotes */ = {
+			isa = PBXGroup;
+			children = (
+				1709ADDF251B9A110053AF79 /* EditorLaunchingPolicy.md */,
+			);
+			path = Technotes;
+			sourceTree = "<group>";
+		};
 		17120DA624E19CE2002B9F6C /* Settings */ = {
 			isa = PBXGroup;
 			children = (
@@ -295,6 +304,7 @@
 				17DF32CA24C8856C00BCE2E3 /* CHANGELOG.md */,
 				17DF32C724C8853700BCE2E3 /* CODE_OF_CONDUCT.md */,
 				17DF32C824C8854B00BCE2E3 /* CONTRIBUTING.md */,
+				1709ADDE251B99D40053AF79 /* Technotes */,
 				17DF328024C87D3300BCE2E3 /* Shared */,
 				17DF328A24C87D3500BCE2E3 /* iOS */,
 				17DF329124C87D3500BCE2E3 /* macOS */,

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		170DFA34251BBC44001D82A0 /* PostEditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170DFA33251BBC44001D82A0 /* PostEditorModel.swift */; };
+		170DFA35251BBC44001D82A0 /* PostEditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 170DFA33251BBC44001D82A0 /* PostEditorModel.swift */; };
 		17120DA124E19839002B9F6C /* AccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5388D24DDEC7400DEFF9A /* AccountView.swift */; };
 		17120DA224E1985C002B9F6C /* AccountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5388B24DDC83F00DEFF9A /* AccountModel.swift */; };
 		17120DA324E19A42002B9F6C /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5389124DDED0000DEFF9A /* PreferencesView.swift */; };
@@ -102,6 +104,7 @@
 
 /* Begin PBXFileReference section */
 		1709ADDF251B9A110053AF79 /* EditorLaunchingPolicy.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = EditorLaunchingPolicy.md; sourceTree = "<group>"; };
+		170DFA33251BBC44001D82A0 /* PostEditorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorModel.swift; sourceTree = "<group>"; };
 		17120DA424E19CBF002B9F6C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		17120DA824E1B2F5002B9F6C /* AccountLogoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLogoutView.swift; sourceTree = "<group>"; };
 		17120DAB24E1B99F002B9F6C /* AccountLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLoginView.swift; sourceTree = "<group>"; };
@@ -214,6 +217,7 @@
 		1739B8D324EAFAB700DA7421 /* PostEditor */ = {
 			isa = PBXGroup;
 			children = (
+				170DFA33251BBC44001D82A0 /* PostEditorModel.swift */,
 				1756DBB224FECDBB00207AB8 /* PostEditorStatusToolbarView.swift */,
 			);
 			path = PostEditor;
@@ -650,6 +654,7 @@
 				1756DBBA24FED45500207AB8 /* LocalStorageManager.swift in Sources */,
 				1756AE8124CB844500FD7257 /* View+Keyboard.swift in Sources */,
 				17C42E652509237800072984 /* PostListFilteredView.swift in Sources */,
+				170DFA34251BBC44001D82A0 /* PostEditorModel.swift in Sources */,
 				17120DAC24E1B99F002B9F6C /* AccountLoginView.swift in Sources */,
 				17480CA5251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */,
 				17120DA924E1B2F5002B9F6C /* AccountLogoutView.swift in Sources */,
@@ -710,6 +715,7 @@
 				1756DC0224FEE18400207AB8 /* WFACollection+CoreDataClass.swift in Sources */,
 				1756DBB424FECDBB00207AB8 /* PostEditorStatusToolbarView.swift in Sources */,
 				17A5388F24DDEC7400DEFF9A /* AccountView.swift in Sources */,
+				170DFA35251BBC44001D82A0 /* PostEditorModel.swift in Sources */,
 				1756AE7524CB26FA00FD7257 /* PostCellView.swift in Sources */,
 				17A5388824DDA31F00DEFF9A /* MacAccountView.swift in Sources */,
 				17C42E632507D8E600072984 /* PostStatus.swift in Sources */,

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -107,7 +107,7 @@ struct PostEditorView: View {
             }
         })
         .onDisappear(perform: {
-            if post.status < PostStatus.published.rawValue {
+            if post.status != PostStatus.published.rawValue {
                 DispatchQueue.main.async {
                     LocalStorageManager().saveContext()
                 }

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -111,6 +111,10 @@ struct PostEditorView: View {
                 DispatchQueue.main.async {
                     model.editor.setLastDraft(post)
                 }
+            } else {
+                DispatchQueue.main.async {
+                    model.editor.clearLastDraft()
+                }
             }
         })
         .onDisappear(perform: {

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -106,6 +106,13 @@ struct PostEditorView: View {
                 post.status = PostStatus.published.rawValue
             }
         })
+        .onChange(of: post.status, perform: { _ in
+            if post.status != PostStatus.published.rawValue {
+                DispatchQueue.main.async {
+                    model.editor.setLastDraft(post)
+                }
+            }
+        })
         .onDisappear(perform: {
             if post.status != PostStatus.published.rawValue {
                 DispatchQueue.main.async {

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -128,6 +128,13 @@ struct PostEditorView: View {
                 post.status = PostStatus.published.rawValue
             }
         })
+        .onChange(of: post.status, perform: { _ in
+            if post.status != PostStatus.published.rawValue {
+                DispatchQueue.main.async {
+                    model.editor.setLastDraft(post)
+                }
+            }
+        })
         .onDisappear(perform: {
             if post.status != PostStatus.published.rawValue {
                 DispatchQueue.main.async {

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -140,6 +140,10 @@ struct PostEditorView: View {
                 DispatchQueue.main.async {
                     LocalStorageManager().saveContext()
                 }
+            } else {
+                DispatchQueue.main.async {
+                    model.editor.clearLastDraft()
+                }
             }
         })
     }

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -129,7 +129,7 @@ struct PostEditorView: View {
             }
         })
         .onDisappear(perform: {
-            if post.status < PostStatus.published.rawValue {
+            if post.status != PostStatus.published.rawValue {
                 DispatchQueue.main.async {
                     LocalStorageManager().saveContext()
                 }


### PR DESCRIPTION
Closes #9.

This PR also adds a first technote: a document describing the policy for deciding what post should be loaded into the editor on launch.