### PR TITLE
Add secure protocol to server string if it's missing

### DIFF
--- a/Shared/Account/AccountLoginView.swift
+++ b/Shared/Account/AccountLoginView.swift
@@ -52,6 +52,10 @@ struct AccountLoginView: View {
                     .padding()
             } else {
                 Button(action: {
+                    let secureProtocolPrefix = "https://"
+                    if !server.hasPrefix(secureProtocolPrefix) {
+                        server = secureProtocolPrefix + server
+                    }
                     model.login(
                         to: URL(string: server)!,
                         as: username, password: password

--- a/Shared/Account/AccountLoginView.swift
+++ b/Shared/Account/AccountLoginView.swift
@@ -65,11 +65,10 @@ struct AccountLoginView: View {
                 .padding()
             }
         }
-        .alert(isPresented: $model.account.hasError) {
-            guard let accountError = model.account.currentError else { fatalError() }
-            return Alert(
+        .alert(isPresented: $model.isPresentingLoginErrorAlert) {
+            Alert(
                 title: Text("Error Logging In"),
-                message: Text(accountError.localizedDescription),
+                message: Text(model.loginErrorMessage ?? "An unknown error occurred while trying to login."),
                 dismissButton: .default(Text("OK"))
             )
         }

--- a/Shared/Account/AccountLoginView.swift
+++ b/Shared/Account/AccountLoginView.swift
@@ -52,10 +52,6 @@ struct AccountLoginView: View {
                     .padding()
             } else {
                 Button(action: {
-                    let secureProtocolPrefix = "https://"
-                    if !server.hasPrefix(secureProtocolPrefix) {
-                        server = secureProtocolPrefix + server
-                    }
                     model.login(
                         to: URL(string: server)!,
                         as: username, password: password

--- a/Shared/Account/AccountModel.swift
+++ b/Shared/Account/AccountModel.swift
@@ -37,12 +37,7 @@ struct AccountModel {
 
     var server: String = ""
     var username: String = ""
-    var hasError: Bool = false
-    var currentError: AccountError? {
-        didSet {
-            hasError = true
-        }
-    }
+
     private(set) var user: WFUser?
     private(set) var isLoggedIn: Bool = false
 

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -26,10 +26,13 @@ class WriteFreelyModel: ObservableObject {
         }
     }
     @Published var isPresentingDeleteAlert: Bool = false
+    @Published var isPresentingLoginErrorAlert: Bool = false
     @Published var postToDelete: WFAPost?
     #if os(iOS)
     @Published var isPresentingSettingsView: Bool = false
     #endif
+
+    var loginErrorMessage: String?
 
     // swiftlint:disable line_length
     let helpURL = URL(string: "https://discuss.write.as/c/help/5")!
@@ -188,17 +191,25 @@ private extension WriteFreelyModel {
             }
         } catch WFError.notFound {
             DispatchQueue.main.async {
-                self.account.currentError = AccountError.usernameNotFound
+                self.loginErrorMessage = AccountError.usernameNotFound.localizedDescription
+                self.isPresentingLoginErrorAlert = true
             }
         } catch WFError.unauthorized {
             DispatchQueue.main.async {
-                self.account.currentError = AccountError.invalidPassword
+                self.loginErrorMessage = AccountError.invalidPassword.localizedDescription
+                self.isPresentingLoginErrorAlert = true
             }
         } catch {
             if (error as NSError).domain == NSURLErrorDomain,
                (error as NSError).code == -1003 {
                 DispatchQueue.main.async {
-                    self.account.currentError = AccountError.serverNotFound
+                    self.loginErrorMessage = AccountError.serverNotFound.localizedDescription
+                    self.isPresentingLoginErrorAlert = true
+                }
+            } else {
+                DispatchQueue.main.async {
+                    self.loginErrorMessage = error.localizedDescription
+                    self.isPresentingLoginErrorAlert = true
                 }
             }
         }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -79,9 +79,20 @@ class WriteFreelyModel: ObservableObject {
 
 extension WriteFreelyModel {
     func login(to server: URL, as username: String, password: String) {
+        let secureProtocolPrefix = "https://"
+        let insecureProtocolPrefix = "http://"
+        var serverString = server.absoluteString
+        // If there's neither an http or https prefix, prepend "https://" to the server string.
+        if !(serverString.hasPrefix(secureProtocolPrefix) || serverString.hasPrefix(insecureProtocolPrefix)) {
+            serverString = secureProtocolPrefix + serverString
+        }
+        // If the server string is prefixed with http, upgrade to https before attempting to login.
+        if serverString.hasPrefix(insecureProtocolPrefix) {
+            serverString = serverString.replacingOccurrences(of: insecureProtocolPrefix, with: secureProtocolPrefix)
+        }
         isLoggingIn = true
-        account.server = server.absoluteString
-        client = WFClient(for: server)
+        account.server = serverString
+        client = WFClient(for: URL(string: serverString)!)
         client?.login(username: username, password: password, completion: loginHandler)
     }
 

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
Closes #71.

This PR adds a check in the AccountLoginView — when the user taps the login button, it prepends the "https://" prefix to the server string if it's missing before logging in.