### PR TITLE
Always launch to editor

### DIFF
--- a/Shared/Account/AccountLoginView.swift
+++ b/Shared/Account/AccountLoginView.swift
@@ -65,11 +65,10 @@ struct AccountLoginView: View {
                 .padding()
             }
         }
-        .alert(isPresented: $model.account.hasError) {
-            guard let accountError = model.account.currentError else { fatalError() }
-            return Alert(
+        .alert(isPresented: $model.isPresentingLoginErrorAlert) {
+            Alert(
                 title: Text("Error Logging In"),
-                message: Text(accountError.localizedDescription),
+                message: Text(model.loginErrorMessage ?? "An unknown error occurred while trying to login."),
                 dismissButton: .default(Text("OK"))
             )
         }

--- a/Shared/Account/AccountModel.swift
+++ b/Shared/Account/AccountModel.swift
@@ -37,12 +37,7 @@ struct AccountModel {
 
     var server: String = ""
     var username: String = ""
-    var hasError: Bool = false
-    var currentError: AccountError? {
-        didSet {
-            hasError = true
-        }
-    }
+
     private(set) var user: WFUser?
     private(set) var isLoggedIn: Bool = false
 

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -12,19 +12,7 @@ class WriteFreelyModel: ObservableObject {
     @Published var editor = PostEditorModel()
     @Published var isLoggingIn: Bool = false
     @Published var hasNetworkConnection: Bool = false
-    @Published var selectedPost: WFAPost? {
-        didSet {
-            if let post = selectedPost {
-                if post.status != PostStatus.published.rawValue {
-                    editor.setLastDraft(post)
-                } else {
-                    editor.clearLastDraft()
-                }
-            } else {
-                editor.clearLastDraft()
-            }
-        }
-    }
+    @Published var selectedPost: WFAPost?
     @Published var isPresentingDeleteAlert: Bool = false
     @Published var isPresentingLoginErrorAlert: Bool = false
     @Published var postToDelete: WFAPost?

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -3,6 +3,14 @@ import SwiftUI
 struct ContentView: View {
     @EnvironmentObject var model: WriteFreelyModel
 
+    #if os(iOS)
+    let didFinishLaunchingNotification = UIApplication.didFinishLaunchingNotification
+    let didBecomeActiveNotification = UIApplication.didBecomeActiveNotification
+    #elseif os(macOS)
+    let didFinishLaunchingNotification = NSApplication.didFinishLaunchingNotification
+    let didBecomeActiveNotification = NSApplication.didBecomeActiveNotification
+    #endif
+
     var body: some View {
         NavigationView {
             SidebarView()
@@ -12,30 +20,19 @@ struct ContentView: View {
             Text("Select a post, or create a new local draft.")
                 .foregroundColor(.secondary)
         }
-        .onAppear(perform: {
-            if let lastDraft = self.model.editor.fetchLastDraft() {
-                model.selectedPost = lastDraft
-            } else {
-                let managedPost = WFAPost(context: LocalStorageManager.persistentContainer.viewContext)
-                managedPost.createdDate = Date()
-                managedPost.title = ""
-                managedPost.body = ""
-                managedPost.status = PostStatus.local.rawValue
-                switch self.model.preferences.font {
-                case 1:
-                    managedPost.appearance = "sans"
-                case 2:
-                    managedPost.appearance = "wrap"
-                default:
-                    managedPost.appearance = "serif"
-                }
-                if let languageCode = Locale.current.languageCode {
-                    managedPost.language = languageCode
-                    managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
-                }
-                model.selectedPost = managedPost
-            }
-        })
+        .onReceive(NotificationCenter.default.publisher(for: didFinishLaunchingNotification)) { _ in
+            #if os(macOS)
+            launchToEditor()
+            #endif
+        }
+        .onReceive(NotificationCenter.default.publisher(for: didBecomeActiveNotification)) { _ in
+            launchToEditor()
+        }
+        .onAppear {
+            #if os(iOS)
+            launchToEditor()
+            #endif
+        }
         .environmentObject(model)
         .alert(isPresented: $model.isPresentingDeleteAlert) {
             Alert(
@@ -67,6 +64,35 @@ struct ContentView: View {
                 }
             )
         #endif
+    }
+
+    private func launchToEditor() {
+        if let lastDraft = self.model.editor.fetchLastDraft() {
+            DispatchQueue.main.async {
+                model.selectedPost = lastDraft
+            }
+        } else {
+            let managedPost = WFAPost(context: LocalStorageManager.persistentContainer.viewContext)
+            managedPost.createdDate = Date()
+            managedPost.title = ""
+            managedPost.body = ""
+            managedPost.status = PostStatus.local.rawValue
+            switch self.model.preferences.font {
+            case 1:
+                managedPost.appearance = "sans"
+            case 2:
+                managedPost.appearance = "wrap"
+            default:
+                managedPost.appearance = "serif"
+            }
+            if let languageCode = Locale.current.languageCode {
+                managedPost.language = languageCode
+                managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
+            }
+            DispatchQueue.main.async {
+                model.selectedPost = managedPost
+            }
+        }
     }
 }
 

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -107,17 +107,19 @@ struct PostEditorView: View {
             }
         })
         .onChange(of: post.status, perform: { _ in
-            if post.status != PostStatus.published.rawValue {
-                DispatchQueue.main.async {
-                    model.editor.setLastDraft(post)
-                }
+            if post.status == PostStatus.published.rawValue {
+                model.editor.clearLastDraft()
             } else {
-                DispatchQueue.main.async {
-                    model.editor.clearLastDraft()
-                }
+                model.editor.setLastDraft(post)
+            }
+        })
+        .onAppear(perform: {
+            if post.status != PostStatus.published.rawValue {
+                model.editor.setLastDraft(post)
             }
         })
         .onDisappear(perform: {
+            model.editor.clearLastDraft()
             if post.title.count == 0
                 && post.body.count == 0
                 && post.status == PostStatus.local.rawValue

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -129,17 +129,19 @@ struct PostEditorView: View {
             }
         })
         .onChange(of: post.status, perform: { _ in
-            if post.status != PostStatus.published.rawValue {
-                DispatchQueue.main.async {
-                    model.editor.setLastDraft(post)
-                }
+            if post.status == PostStatus.published.rawValue {
+                model.editor.clearLastDraft()
             } else {
-                DispatchQueue.main.async {
-                    model.editor.clearLastDraft()
-                }
+                model.editor.setLastDraft(post)
+            }
+        })
+        .onAppear(perform: {
+            if post.status != PostStatus.published.rawValue {
+                model.editor.setLastDraft(post)
             }
         })
         .onDisappear(perform: {
+            model.editor.clearLastDraft()
             if post.title.count == 0
                 && post.body.count == 0
                 && post.status == PostStatus.local.rawValue


### PR DESCRIPTION
Closes #76.

This PR make it more reliable to load the post editor with the last-draft/new-post policy implemented in #70.

There is, however, some buggy behaviour with iOS 14 that I've had to workaround to get this working, and it's not 100% there (though it does get back the correct animation from list to editor on launch, so that's a win). I've tried to get some clarification on this on the [Apple Developer forums](https://developer.apple.com/forums/thread/661909) and I'm going to file a radar on this as well.