### PR TITLE
Add share button to iOS target

### DIFF
--- a/Shared/PostEditor/PostEditorStatusToolbarView.swift
+++ b/Shared/PostEditor/PostEditorStatusToolbarView.swift
@@ -35,7 +35,9 @@ struct PostEditorStatusToolbarView: View {
                     .foregroundColor(.secondary)
                 Button(action: {
                     model.selectedPost = nil
-                    model.posts.remove(post)
+                    DispatchQueue.main.async {
+                        model.posts.remove(post)
+                    }
                 }, label: {
                     Image(systemName: "trash")
                 })

--- a/Shared/PostEditor/PostEditorStatusToolbarView.swift
+++ b/Shared/PostEditor/PostEditorStatusToolbarView.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
 struct PostEditorStatusToolbarView: View {
-    #if os(iOS)
-    @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    @Environment(\.presentationMode) var presentationMode
-    #endif
     @EnvironmentObject var model: WriteFreelyModel
 
     @ObservedObject var post: WFAPost
@@ -12,36 +8,7 @@ struct PostEditorStatusToolbarView: View {
     var body: some View {
         if post.hasNewerRemoteCopy {
             #if os(iOS)
-            if horizontalSizeClass == .compact {
-                VStack {
-                    PostStatusBadgeView(post: post)
-                    HStack {
-                        Text("⚠️ Newer copy on server. Replace local copy?")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Button(action: {
-                            model.updateFromServer(post: post)
-                        }, label: {
-                            Image(systemName: "square.and.arrow.down")
-                        })
-                    }
-                    .padding(.bottom)
-                }
-                .padding(.top)
-            } else {
-                HStack {
-                    PostStatusBadgeView(post: post)
-                        .padding(.trailing)
-                    Text("⚠️ Newer copy on server. Replace local copy?")
-                        .font(.callout)
-                        .foregroundColor(.secondary)
-                    Button(action: {
-                        model.updateFromServer(post: post)
-                    }, label: {
-                        Image(systemName: "square.and.arrow.down")
-                    })
-                }
-            }
+            PostStatusBadgeView(post: post)
             #else
             HStack {
                 PostStatusBadgeView(post: post)
@@ -58,45 +25,12 @@ struct PostEditorStatusToolbarView: View {
             #endif
         } else if post.wasDeletedFromServer && post.status != PostStatus.local.rawValue {
             #if os(iOS)
-            if horizontalSizeClass == .compact {
-                VStack {
-                    PostStatusBadgeView(post: post)
-                    HStack {
-                        Text("‼️ Post deleted from server. Delete local copy?")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Button(action: {
-                            self.presentationMode.wrappedValue.dismiss()
-                            model.selectedPost = nil
-                            model.posts.remove(post)
-                        }, label: {
-                            Image(systemName: "trash")
-                        })
-                    }
-                    .padding(.bottom)
-                }
-                .padding(.top)
-            } else {
-                HStack {
-                    PostStatusBadgeView(post: post)
-                        .padding(.trailing)
-                    Text("‼️ Post deleted from server. Delete local copy?")
-                        .font(.callout)
-                        .foregroundColor(.secondary)
-                    Button(action: {
-                        self.presentationMode.wrappedValue.dismiss()
-                        model.selectedPost = nil
-                        model.posts.remove(post)
-                    }, label: {
-                        Image(systemName: "trash")
-                    })
-                }
-            }
+            PostStatusBadgeView(post: post)
             #else
             HStack {
                 PostStatusBadgeView(post: post)
                     .padding(.trailing)
-                Text("‼️ Post deleted from server. Delete local copy?")
+                Text("⚠️ Post deleted from server. Delete local copy?")
                     .font(.callout)
                     .foregroundColor(.secondary)
                 Button(action: {

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -2,11 +2,45 @@ import SwiftUI
 
 struct PostEditorView: View {
     @EnvironmentObject var model: WriteFreelyModel
-
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.presentationMode) var presentationMode
     @ObservedObject var post: WFAPost
 
     var body: some View {
         VStack {
+            if post.hasNewerRemoteCopy {
+                HStack {
+                    Text("⚠️ Newer copy on server. Replace local copy?")
+                        .font(horizontalSizeClass == .compact ? .caption : .body)
+                        .foregroundColor(.secondary)
+                    Button(action: {
+                        model.updateFromServer(post: post)
+                    }, label: {
+                        Image(systemName: "square.and.arrow.down")
+                    })
+                }
+                .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
+                .background(Color(UIColor.secondarySystemBackground))
+                .clipShape(Capsule())
+                .padding(.bottom)
+            } else if post.wasDeletedFromServer {
+                HStack {
+                    Text("⚠️ Post deleted from server. Delete local copy?")
+                        .font(horizontalSizeClass == .compact ? .caption : .body)
+                        .foregroundColor(.secondary)
+                    Button(action: {
+                        self.presentationMode.wrappedValue.dismiss()
+                        model.selectedPost = nil
+                        model.posts.remove(post)
+                    }, label: {
+                        Image(systemName: "trash")
+                    })
+                }
+                .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
+                .background(Color(UIColor.secondarySystemBackground))
+                .clipShape(Capsule())
+                .padding(.bottom)
+            }
             switch post.appearance {
             case "sans":
                 TextField("Title (optional)", text: $post.title)
@@ -197,6 +231,7 @@ struct PostEditorView_ExistingPostPreviews: PreviewProvider {
         testPost.body = "Here's some cool sample body text."
         testPost.createdDate = Date()
         testPost.appearance = "code"
+        testPost.hasNewerRemoteCopy = true
 
         let model = WriteFreelyModel()
 

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -152,6 +152,15 @@ struct PostEditorView: View {
         self.hideKeyboard()
         #endif
     }
+
+    private func sharePost() {
+        guard let urlString = model.selectedPost?.slug != nil ?
+                "\(model.account.server)/\((model.selectedPost?.collectionAlias)!)/\((model.selectedPost?.slug)!)" :
+                "\(model.account.server)/\((model.selectedPost?.postId)!)" else { return }
+        guard let data = URL(string: urlString) else { return }
+        let activityView = UIActivityViewController(activityItems: [data], applicationActivities: nil)
+        UIApplication.shared.windows.first?.rootViewController?.present(activityView, animated: true, completion: nil)
+    }
 }
 
 struct PostEditorView_EmptyPostPreviews: PreviewProvider {

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -90,13 +90,6 @@ struct PostEditorView: View {
             }
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 Button(action: {
-                    sharePost()
-                }, label: {
-                    Image(systemName: "square.and.arrow.up")
-                })
-                .disabled(post.postId == nil)
-
-                Button(action: {
                     publishPost()
                 }, label: {
                     Image(systemName: "paperplane")
@@ -106,6 +99,12 @@ struct PostEditorView: View {
                         !model.account.isLoggedIn ||
                         !model.hasNetworkConnection
                 )
+                Button(action: {
+                    sharePost()
+                }, label: {
+                    Image(systemName: "square.and.arrow.up")
+                })
+                .disabled(post.postId == nil)
             }
         }
         .onChange(of: post.hasNewerRemoteCopy, perform: { _ in
@@ -158,8 +157,20 @@ struct PostEditorView: View {
                 "\(model.account.server)/\((model.selectedPost?.collectionAlias)!)/\((model.selectedPost?.slug)!)" :
                 "\(model.account.server)/\((model.selectedPost?.postId)!)" else { return }
         guard let data = URL(string: urlString) else { return }
+
         let activityView = UIActivityViewController(activityItems: [data], applicationActivities: nil)
+
         UIApplication.shared.windows.first?.rootViewController?.present(activityView, animated: true, completion: nil)
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            activityView.popoverPresentationController?.permittedArrowDirections = .up
+            activityView.popoverPresentationController?.sourceView = UIApplication.shared.windows.first
+            activityView.popoverPresentationController?.sourceRect = CGRect(
+                x: UIScreen.main.bounds.width,
+                y: -125,
+                width: 200,
+                height: 200
+            )
+        }
     }
 }
 

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -88,7 +88,14 @@ struct PostEditorView: View {
             ToolbarItem(placement: .principal) {
                 PostEditorStatusToolbarView(post: post)
             }
-            ToolbarItem(placement: .primaryAction) {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button(action: {
+                    sharePost()
+                }, label: {
+                    Image(systemName: "square.and.arrow.up")
+                })
+                .disabled(post.postId == nil)
+
                 Button(action: {
                     publishPost()
                 }, label: {

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -30,8 +30,9 @@ struct PostEditorView: View {
                         .foregroundColor(.secondary)
                     Button(action: {
                         self.presentationMode.wrappedValue.dismiss()
-                        model.selectedPost = nil
-                        model.posts.remove(post)
+                        DispatchQueue.main.async {
+                            model.posts.remove(post)
+                        }
                     }, label: {
                         Image(systemName: "trash")
                     })
@@ -163,7 +164,7 @@ struct PostEditorView: View {
                 && post.status == PostStatus.local.rawValue
                 && post.updatedDate == nil
                 && post.postId == nil {
-                withAnimation {
+                DispatchQueue.main.async {
                     model.posts.remove(post)
                     model.posts.loadCachedPosts()
                 }

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -145,7 +145,7 @@ struct PostEditorView: View {
                 && post.status == PostStatus.local.rawValue
                 && post.updatedDate == nil
                 && post.postId == nil {
-                withAnimation {
+                DispatchQueue.main.async {
                     model.posts.remove(post)
                     model.posts.loadCachedPosts()
                 }


### PR DESCRIPTION
Closes #41.

This PR adds a share button with share-sheet functionality to the iOS app target, and improves the layout of the editor, moving the prompt for out-of-sync copies (i.e., newer or deleted copy of the post on the server) out of the toolbar.

It also fixes a crashing bug when deleting a post from persistent storage while the application still retains ownership of the object.