### PR TITLE
Open the preferences window on publish if not logged in [macOS]

### DIFF
--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -115,7 +115,10 @@ struct PostEditorView: View {
                     if model.account.isLoggedIn {
                         publishPost()
                     } else {
-                        // TODO: Open the Preferences window.
+                        let mainMenu = NSApplication.shared.mainMenu
+                        let appMenuItem = mainMenu?.item(withTitle: "WriteFreely")
+                        let prefsItem = appMenuItem?.submenu?.item(withTitle: "Preferences…")
+                        NSApplication.shared.sendAction(prefsItem!.action!, to: prefsItem?.target, from: nil)
                     }
                 }, label: {
                     Image(systemName: "paperplane")


### PR DESCRIPTION
Closes #82.

(Again.)

This PR opens the Mac app's Preferences window if the user is logged out when they attempt to publish a post.