### PR TITLE
Keep cached post's collectionAlias from being set to nil by fetched post

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -324,6 +324,10 @@ private extension WriteFreelyModel {
     }
 
     func publishHandler(result: Result<WFPost, Error>) {
+        // ⚠️ NOTE:
+        // The API does not return a collection alias, so we take care not to overwrite the
+        // cached post's collection alias with the 'nil' value from the fetched post.
+        // See: https://github.com/writeas/writefreely-swift/issues/20
         do {
             let fetchedPost = try result.get()
             let foundPostIndex = posts.userPosts.firstIndex(where: {
@@ -333,7 +337,6 @@ private extension WriteFreelyModel {
             let cachedPost = self.posts.userPosts[index]
             cachedPost.appearance = fetchedPost.appearance
             cachedPost.body = fetchedPost.body
-            cachedPost.collectionAlias = fetchedPost.collectionAlias
             cachedPost.createdDate = fetchedPost.createdDate
             cachedPost.language = fetchedPost.language
             cachedPost.postId = fetchedPost.postId


### PR DESCRIPTION
Closes #92.

This PR applies the same logic to the WriteFreelyModel's `publishHandler(result:)` method as is used in its `updateFromServerHandler(result:)` method — because the API doesn't return a collection alias for the post, the fetched post has a `collectionAlias` property that's set to `nil`, and so the cached local post's `collectionAlias` property was being un-set in the `publishHandler(result:)` method.