### PR TITLE
Only update post status if we're not updating from the server

### DIFF
--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -5,6 +5,8 @@ struct PostEditorView: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.presentationMode) var presentationMode
     @ObservedObject var post: WFAPost
+    @State private var updatingTitleFromServer: Bool = false
+    @State private var updatingBodyFromServer: Bool = false
 
     var body: some View {
         VStack {
@@ -47,8 +49,11 @@ struct PostEditorView: View {
                 TextField("Title (optional)", text: $post.title)
                     .font(.custom("OpenSans-Regular", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue {
+                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
                             post.status = PostStatus.edited.rawValue
+                        }
+                        if updatingTitleFromServer {
+                            updatingTitleFromServer = false
                         }
                     }
                 ZStack(alignment: .topLeading) {
@@ -62,8 +67,11 @@ struct PostEditorView: View {
                     TextEditor(text: $post.body)
                         .font(.custom("OpenSans-Regular", size: 17, relativeTo: Font.TextStyle.body))
                         .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue {
+                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                                 post.status = PostStatus.edited.rawValue
+                            }
+                            if updatingBodyFromServer {
+                                updatingBodyFromServer = false
                             }
                     }
                 }
@@ -71,8 +79,11 @@ struct PostEditorView: View {
                 TextField("Title (optional)", text: $post.title)
                     .font(.custom("Hack", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue {
+                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
                             post.status = PostStatus.edited.rawValue
+                        }
+                        if updatingTitleFromServer {
+                            updatingTitleFromServer = false
                         }
                     }
                 ZStack(alignment: .topLeading) {
@@ -86,8 +97,11 @@ struct PostEditorView: View {
                     TextEditor(text: $post.body)
                         .font(.custom("Hack", size: 17, relativeTo: Font.TextStyle.body))
                         .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue {
+                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                                 post.status = PostStatus.edited.rawValue
+                            }
+                            if updatingBodyFromServer {
+                                updatingBodyFromServer = false
                             }
                     }
                 }
@@ -95,8 +109,11 @@ struct PostEditorView: View {
                 TextField("Title (optional)", text: $post.title)
                     .font(.custom("Lora", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue {
+                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
                             post.status = PostStatus.edited.rawValue
+                        }
+                        if updatingTitleFromServer {
+                            updatingTitleFromServer = false
                         }
                     }
                 ZStack(alignment: .topLeading) {
@@ -110,8 +127,11 @@ struct PostEditorView: View {
                     TextEditor(text: $post.body)
                         .font(.custom("Lora", size: 17, relativeTo: Font.TextStyle.body))
                         .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue {
+                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                                 post.status = PostStatus.edited.rawValue
+                            }
+                            if updatingBodyFromServer {
+                                updatingBodyFromServer = false
                             }
                     }
                 }
@@ -145,8 +165,9 @@ struct PostEditorView: View {
             }
         }
         .onChange(of: post.hasNewerRemoteCopy, perform: { _ in
-            if post.status == PostStatus.edited.rawValue && !post.hasNewerRemoteCopy {
-                post.status = PostStatus.published.rawValue
+            if !post.hasNewerRemoteCopy {
+                updatingTitleFromServer = true
+                updatingBodyFromServer = true
             }
         })
         .onChange(of: post.status, perform: { _ in

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -5,6 +5,8 @@ struct PostEditorView: View {
 
     @ObservedObject var post: WFAPost
     @State private var isHovering: Bool = false
+    @State private var updatingTitleFromServer: Bool = false
+    @State private var updatingBodyFromServer: Bool = false
 
     var body: some View {
         VStack {
@@ -15,8 +17,11 @@ struct PostEditorView: View {
                     .padding(.bottom)
                     .font(.custom("OpenSans-Regular", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue {
+                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
                             post.status = PostStatus.edited.rawValue
+                        }
+                        if updatingTitleFromServer {
+                            updatingTitleFromServer = false
                         }
                     }
                 ZStack(alignment: .topLeading) {
@@ -31,8 +36,11 @@ struct PostEditorView: View {
                         .font(.custom("OpenSans-Regular", size: 17, relativeTo: Font.TextStyle.body))
                         .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
                         .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue {
+                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                                 post.status = PostStatus.edited.rawValue
+                            }
+                            if updatingBodyFromServer {
+                                updatingBodyFromServer = false
                             }
                         }
                         .onHover(perform: { hovering in
@@ -46,8 +54,11 @@ struct PostEditorView: View {
                     .padding(.bottom)
                     .font(.custom("Hack", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue {
+                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
                             post.status = PostStatus.edited.rawValue
+                        }
+                        if updatingTitleFromServer {
+                            updatingTitleFromServer = false
                         }
                     }
                 ZStack(alignment: .topLeading) {
@@ -62,8 +73,11 @@ struct PostEditorView: View {
                         .font(.custom("Hack", size: 17, relativeTo: Font.TextStyle.body))
                         .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
                         .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue {
+                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                                 post.status = PostStatus.edited.rawValue
+                            }
+                            if updatingBodyFromServer {
+                                updatingBodyFromServer = false
                             }
                         }
                         .onHover(perform: { hovering in
@@ -77,8 +91,11 @@ struct PostEditorView: View {
                     .padding(.bottom)
                     .font(.custom("Lora", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue {
+                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
                             post.status = PostStatus.edited.rawValue
+                        }
+                        if updatingTitleFromServer {
+                            updatingTitleFromServer = false
                         }
                     }
                 ZStack(alignment: .topLeading) {
@@ -93,8 +110,11 @@ struct PostEditorView: View {
                         .font(.custom("Lora", size: 17, relativeTo: Font.TextStyle.body))
                         .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
                         .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue {
+                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                                 post.status = PostStatus.edited.rawValue
+                            }
+                            if updatingBodyFromServer {
+                                updatingBodyFromServer = false
                             }
                         }
                         .onHover(perform: { hovering in


### PR DESCRIPTION
Closes #92.

This PR fixes an issue where the post's status would be changed from **Published** to **Edited** when updating the post to a newer version from the server.