### PR TITLE
Remove URL path from server string before logging in

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -95,7 +95,11 @@ extension WriteFreelyModel {
         }
         isLoggingIn = true
         account.server = serverString
-        client = WFClient(for: URL(string: serverString)!)
+        var serverURL = URL(string: serverString)!
+        if !serverURL.path.isEmpty {
+            serverURL.deleteLastPathComponent()
+        }
+        client = WFClient(for: serverURL)
         client?.login(username: username, password: password, completion: loginHandler)
     }
 

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -94,11 +94,11 @@ extension WriteFreelyModel {
             serverString = serverString.replacingOccurrences(of: insecureProtocolPrefix, with: secureProtocolPrefix)
         }
         isLoggingIn = true
-        account.server = serverString
         var serverURL = URL(string: serverString)!
         if !serverURL.path.isEmpty {
             serverURL.deleteLastPathComponent()
         }
+        account.server = serverURL.absoluteString
         client = WFClient(for: serverURL)
         client?.login(username: username, password: password, completion: loginHandler)
     }

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -1141,7 +1141,7 @@
 			repositoryURL = "git@github.com:writeas/writefreely-swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.1;
+				minimumVersion = 0.2.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Closes #72.

This PR bumps the WriteFreely Swift package dependency to 0.2.3, and also removes any path that might be accidentally appended to the server URL before logging in.