### PR TITLE
Add collection setting menu

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -179,16 +179,8 @@ extension WriteFreelyModel {
         guard let loggedInClient = client,
               let postId = post.postId else { return }
 
-        if let newCollectionAlias = newCollection?.alias {
-            post.collectionAlias = newCollectionAlias
-            loggedInClient.movePost(postId: postId, to: newCollectionAlias, completion: movePostHandler)
-        } else {
-            // Moving a post to Drafts is not yet supported by the Swift package.
-            DispatchQueue.main.async {
-                post.collectionAlias = oldCollection?.alias
-                self.selectedPost = nil
-            }
-        }
+        post.collectionAlias = newCollection?.alias
+        loggedInClient.movePost(postId: postId, to: newCollection?.alias, completion: movePostHandler)
     }
 }
 

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -104,6 +104,7 @@ struct PostListView: View {
         managedPost.title = ""
         managedPost.body = ""
         managedPost.status = PostStatus.local.rawValue
+        managedPost.collectionAlias = nil
         switch model.preferences.font {
         case 1:
             managedPost.appearance = "sans"
@@ -116,11 +117,12 @@ struct PostListView: View {
             managedPost.language = languageCode
             managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
         }
-        if let selectedCollectionAlias = selectedCollection?.alias {
-            managedPost.collectionAlias = selectedCollectionAlias
-        }
         DispatchQueue.main.async {
-            model.selectedPost = managedPost
+            self.selectedCollection = nil
+            self.showAllPosts = false
+            withAnimation {
+                self.model.selectedPost = managedPost
+            }
         }
     }
 }

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -1140,8 +1140,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:writeas/writefreely-swift.git";
 			requirement = {
-				branch = "extend-move-api-to-drafts";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -1140,8 +1140,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "git@github.com:writeas/writefreely-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.1;
+				branch = "extend-move-api-to-drafts";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -183,11 +183,11 @@ struct PostEditorView: View {
                         Label("Share", systemImage: "square.and.arrow.up")
                     })
                     .disabled(post.postId == nil)
-                    Button(action: {
-                        print("Tapped 'Delete...' button")
-                    }, label: {
-                        Label("Delete…", systemImage: "trash")
-                    })
+//                    Button(action: {
+//                        print("Tapped 'Delete...' button")
+//                    }, label: {
+//                        Label("Delete…", systemImage: "trash")
+//                    })
                     if model.account.isLoggedIn && post.status != PostStatus.local.rawValue {
                         Section(header: Text("Move To Collection")) {
                             Label("Move to:", systemImage: "arrowshape.zigzag.right")

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -195,12 +195,12 @@ struct PostEditorView: View {
                 }
             }
         })
-        .onChange(of: selectedCollection, perform: { newValue in
-            if post.collectionAlias != newValue?.alias {
-                post.status = PostStatus.edited.rawValue
-                post.collectionAlias = newValue?.alias
-                model.posts.loadCachedPosts()
-                LocalStorageManager().saveContext()
+        .onChange(of: selectedCollection, perform: { [selectedCollection] newCollection in
+            if post.collectionAlias == newCollection?.alias {
+                return
+            } else {
+                post.collectionAlias = newCollection?.alias
+                model.move(post: post, from: selectedCollection, to: newCollection)
             }
         })
         .onAppear(perform: {

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -144,7 +144,9 @@ struct PostEditorView: View {
                                 } else {
                                     self.model.isPresentingSettingsView = true
                                 }
-                            }, label: { Text("  Drafts") })
+                            }, label: {
+                                Text("  \(model.account.server == "https://write.as" ? "Anonymous" : "Drafts")")
+                            })
                             ForEach(collections) { collection in
                                 Button(action: {
                                     if model.account.isLoggedIn {
@@ -192,7 +194,9 @@ struct PostEditorView: View {
                         Section(header: Text("Move To Collection")) {
                             Label("Move to:", systemImage: "arrowshape.zigzag.right")
                             Picker(selection: $selectedCollection, label: Text("Move to…")) {
-                                Text("  Drafts").tag(nil as WFACollection?)
+                                Text(
+                                    "  \(model.account.server == "https://write.as" ? "Anonymous" : "Drafts")"
+                                ).tag(nil as WFACollection?)
                                 ForEach(collections) { collection in
                                     Text("  \(collection.title)").tag(collection as WFACollection?)
                                 }


### PR DESCRIPTION
Closes #39.

This PR is currently in draft state until writeas/writefreely-swift#23 is closed.

Once that work is complete, this PR implements the following:

- The new-post button now always creates a new local post in Drafts.
- The Publish and Share buttons now live in a menu in the editor.
- Published posts can be moved to a different collection (or Drafts) from a picker in the editor menu
- Unpublished (i.e., local) posts prompt the user to choose a collection to publish to.