### PR TITLE
Fix share link after moving post

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -171,18 +171,14 @@ extension WriteFreelyModel {
         DispatchQueue.main.async {
             self.selectedPost = post
         }
-        if let postCollectionAlias = post.collectionAlias,
-           let postSlug = post.slug {
-            loggedInClient.getPost(bySlug: postSlug, from: postCollectionAlias, completion: updateFromServerHandler)
-        } else {
-            loggedInClient.getPost(byId: postId, completion: updateFromServerHandler)
-        }
+        loggedInClient.getPost(byId: postId, completion: updateFromServerHandler)
     }
 
     func move(post: WFAPost, from oldCollection: WFACollection?, to newCollection: WFACollection?) {
         guard let loggedInClient = client,
               let postId = post.postId else { return }
 
+        selectedPost = post
         post.collectionAlias = newCollection?.alias
         loggedInClient.movePost(postId: postId, to: newCollection?.alias, completion: movePostHandler)
     }

--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -386,6 +386,7 @@ private extension WriteFreelyModel {
             cachedPost.hasNewerRemoteCopy = false
             DispatchQueue.main.async {
                 LocalStorageManager().saveContext()
+                self.posts.loadCachedPosts()
             }
         } catch {
             print(error)
@@ -396,9 +397,10 @@ private extension WriteFreelyModel {
         do {
             let succeeded = try result.get()
             if succeeded {
-                DispatchQueue.main.async {
-                    LocalStorageManager().saveContext()
-                    self.posts.loadCachedPosts()
+                if let post = selectedPost {
+                    updateFromServer(post: post)
+                } else {
+                    return
                 }
             }
         } catch {


### PR DESCRIPTION
Closes #97.

This PR adds a call to `updateFromServer(_:)` from the `movePostHandler(result:)` success path; furthermore, it works around a [silent failure in the Swift package](https://github.com/writeas/writefreely-swift/issues/25) when calling `getPost(bySlug:from:completion:)` in an edge case where the post has a stale post-slug property value (see comments on a2f9d23).