### PR TITLE
Minor editor design improvements

### DIFF
--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct PostEditorView: View {
+    private let bodyLineSpacing: CGFloat = 17 * 0.5
     @EnvironmentObject var model: WriteFreelyModel
     @Environment(\.managedObjectContext) var moc
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
@@ -76,6 +77,7 @@ struct PostEditorView: View {
                     }
                     TextEditor(text: $post.body)
                         .font(.custom("OpenSans-Regular", size: 17, relativeTo: Font.TextStyle.body))
+                        .lineSpacing(bodyLineSpacing)
                         .onChange(of: post.body) { _ in
                             if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                                 post.status = PostStatus.edited.rawValue
@@ -107,6 +109,7 @@ struct PostEditorView: View {
                     }
                     TextEditor(text: $post.body)
                         .font(.custom("Hack", size: 17, relativeTo: Font.TextStyle.body))
+                        .lineSpacing(bodyLineSpacing)
                         .onChange(of: post.body) { _ in
                             if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                                 post.status = PostStatus.edited.rawValue
@@ -138,6 +141,7 @@ struct PostEditorView: View {
                     }
                     TextEditor(text: $post.body)
                         .font(.custom("Lora", size: 17, relativeTo: Font.TextStyle.body))
+                        .lineSpacing(bodyLineSpacing)
                         .onChange(of: post.body) { _ in
                             if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                                 post.status = PostStatus.edited.rawValue

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -56,6 +56,7 @@ struct PostEditorView: View {
             switch post.appearance {
             case "sans":
                 TextField("Title (optional)", text: $post.title)
+                    .padding(.horizontal, 4)
                     .font(.custom("OpenSans-Regular", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
                         if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
@@ -86,6 +87,7 @@ struct PostEditorView: View {
                 }
             case "wrap", "mono", "code":
                 TextField("Title (optional)", text: $post.title)
+                    .padding(.horizontal, 4)
                     .font(.custom("Hack", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
                         if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
@@ -116,6 +118,7 @@ struct PostEditorView: View {
                 }
             default:
                 TextField("Title (optional)", text: $post.title)
+                    .padding(.horizontal, 4)
                     .font(.custom("Lora", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
                         if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct PostEditorView: View {
+    private let bodyLineSpacing: CGFloat = 17 * 0.5
     @EnvironmentObject var model: WriteFreelyModel
 
     @ObservedObject var post: WFAPost
@@ -35,6 +36,7 @@ struct PostEditorView: View {
                     }
                     TextEditor(text: $post.body)
                         .font(.custom("OpenSans-Regular", size: 17, relativeTo: Font.TextStyle.body))
+                        .lineSpacing(bodyLineSpacing)
                         .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
                         .onChange(of: post.body) { _ in
                             if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
@@ -73,6 +75,7 @@ struct PostEditorView: View {
                     }
                     TextEditor(text: $post.body)
                         .font(.custom("Hack", size: 17, relativeTo: Font.TextStyle.body))
+                        .lineSpacing(bodyLineSpacing)
                         .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
                         .onChange(of: post.body) { _ in
                             if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
@@ -111,6 +114,7 @@ struct PostEditorView: View {
                     }
                     TextEditor(text: $post.body)
                         .font(.custom("Lora", size: 17, relativeTo: Font.TextStyle.body))
+                        .lineSpacing(bodyLineSpacing)
                         .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
                         .onChange(of: post.body) { _ in
                             if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -14,6 +14,7 @@ struct PostEditorView: View {
             case "sans":
                 TextField("Title (optional)", text: $post.title)
                     .textFieldStyle(PlainTextFieldStyle())
+                    .padding(.horizontal, 4)
                     .padding(.bottom)
                     .font(.custom("OpenSans-Regular", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
@@ -51,6 +52,7 @@ struct PostEditorView: View {
             case "wrap", "mono", "code":
                 TextField("Title (optional)", text: $post.title)
                     .textFieldStyle(PlainTextFieldStyle())
+                    .padding(.horizontal, 4)
                     .padding(.bottom)
                     .font(.custom("Hack", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in
@@ -88,6 +90,7 @@ struct PostEditorView: View {
             default:
                 TextField("Title (optional)", text: $post.title)
                     .textFieldStyle(PlainTextFieldStyle())
+                    .padding(.horizontal, 4)
                     .padding(.bottom)
                     .font(.custom("Lora", size: 26, relativeTo: Font.TextStyle.largeTitle))
                     .onChange(of: post.title) { _ in


### PR DESCRIPTION
This PR makes a few design tweaks to the editor:

* Aligns the Title field (padding) with the Body field
* Adds some line spacing

Changes were applied on both iOS and macOS, but I was only able to test on iOS.

| Before | After |
| --- | --- |
| ![Simulator Screen Shot - iPhone 8 - 2020-10-21 at 15 56 28](https://user-images.githubusercontent.com/1138779/96776534-25db3d00-13b7-11eb-8644-b5d04e8518dd.png) | ![Simulator Screen Shot - iPhone 8 - 2020-10-21 at 15 57 04](https://user-images.githubusercontent.com/1138779/96776554-2d024b00-13b7-11eb-95f1-be6003d73061.png) |