### PR TITLE
Add link to how-to guide for iOS app

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -38,6 +38,7 @@ class WriteFreelyModel: ObservableObject {
 
     // swiftlint:disable line_length
     let helpURL = URL(string: "https://discuss.write.as/c/help/5")!
+    let howToURL = URL(string: "https://discuss.write.as/t/using-the-writefreely-ios-app/1946")!
     let licensesURL = URL(string: "https://github.com/writeas/writefreely-swiftui-multiplatform/tree/main/Shared/Resources/Licenses")!
     // swiftlint:enable line_length
 

--- a/iOS/Settings/SettingsView.swift
+++ b/iOS/Settings/SettingsView.swift
@@ -13,10 +13,15 @@ struct SettingsView: View {
                 Section(header: Text("Appearance")) {
                     PreferencesView(preferences: model.preferences)
                 }
-                Section(header: Text("Support")) {
+                Section(header: Text("Support Links")) {
                     HStack {
                         Spacer()
-                        Link("Visit Help Forum", destination: model.helpURL)
+                        Link("View the Guide", destination: model.howToURL)
+                        Spacer()
+                    }
+                    HStack {
+                        Spacer()
+                        Link("Visit the Help Forum", destination: model.helpURL)
                         Spacer()
                     }
                 }


### PR DESCRIPTION
Closes #102.

This PR does not include fixes for the Mac app target, since we a) don't have a guide for that, and b) could probably use the standard helpbook for this instead (if that's still a thing?)