### PR TITLE
Refactor PostEditorView

### DIFF
--- a/Shared/PostEditor/PostEditorModel.swift
+++ b/Shared/PostEditor/PostEditorModel.swift
@@ -1,6 +1,12 @@
 import Foundation
 import CoreData
 
+enum PostAppearance: String {
+    case sans = "OpenSans-Regular"
+    case mono = "Hack"
+    case serif = "Lora"
+}
+
 struct PostEditorModel {
     let lastDraftObjectURLKey = "lastDraftObjectURLKey"
     private(set) var lastDraft: WFAPost?

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		17120DB224E1E19C002B9F6C /* SettingsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17120DB124E1E19C002B9F6C /* SettingsHeaderView.swift */; };
 		171BFDFA24D4AF8300888236 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171BFDF924D4AF8300888236 /* CollectionListView.swift */; };
 		171BFDFB24D4AF8300888236 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171BFDF924D4AF8300888236 /* CollectionListView.swift */; };
+		173E19D1254318F600440F0F /* RemoteChangePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173E19D0254318F600440F0F /* RemoteChangePromptView.swift */; };
 		17480CA5251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */; };
 		17480CA6251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */; };
 		174D313224EC2831006CA9EE /* WriteFreelyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174D313124EC2831006CA9EE /* WriteFreelyModel.swift */; };
@@ -117,6 +118,7 @@
 		17120DAB24E1B99F002B9F6C /* AccountLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLoginView.swift; sourceTree = "<group>"; };
 		17120DB124E1E19C002B9F6C /* SettingsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
 		171BFDF924D4AF8300888236 /* CollectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionListView.swift; sourceTree = "<group>"; };
+		173E19D0254318F600440F0F /* RemoteChangePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteChangePromptView.swift; sourceTree = "<group>"; };
 		17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppVersion.swift"; sourceTree = "<group>"; };
 		174D313124EC2831006CA9EE /* WriteFreelyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteFreelyModel.swift; sourceTree = "<group>"; };
 		1753F6AB24E431CC00309365 /* MacPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacPreferencesView.swift; sourceTree = "<group>"; };
@@ -289,6 +291,7 @@
 			isa = PBXGroup;
 			children = (
 				1756AE7624CB2EDD00FD7257 /* PostEditorView.swift */,
+				173E19D0254318F600440F0F /* RemoteChangePromptView.swift */,
 			);
 			path = PostEditor;
 			sourceTree = "<group>";
@@ -680,6 +683,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				17DF32AC24C87D3500BCE2E3 /* ContentView.swift in Sources */,
+				173E19D1254318F600440F0F /* RemoteChangePromptView.swift in Sources */,
 				17C42E622507D8E600072984 /* PostStatus.swift in Sources */,
 				1756DBBA24FED45500207AB8 /* LocalStorageManager.swift in Sources */,
 				1756AE8124CB844500FD7257 /* View+Keyboard.swift in Sources */,

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		17DFDE8A251D309400A25F31 /* Lora-Cyrillic-OFL.txt in Resources */ = {isa = PBXBuildFile; fileRef = 17DFDE85251D309400A25F31 /* Lora-Cyrillic-OFL.txt */; };
 		17DFDE8B251D309400A25F31 /* OpenSans-License.txt in Resources */ = {isa = PBXBuildFile; fileRef = 17DFDE86251D309400A25F31 /* OpenSans-License.txt */; };
 		17DFDE8C251D309400A25F31 /* OpenSans-License.txt in Resources */ = {isa = PBXBuildFile; fileRef = 17DFDE86251D309400A25F31 /* OpenSans-License.txt */; };
+		17E5DF8A2543610700DCDC9B /* PostTextEditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17E5DF892543610700DCDC9B /* PostTextEditingView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -174,6 +175,7 @@
 		17DFDE84251D309400A25F31 /* Hack-License.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Hack-License.txt"; sourceTree = "<group>"; };
 		17DFDE85251D309400A25F31 /* Lora-Cyrillic-OFL.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Lora-Cyrillic-OFL.txt"; sourceTree = "<group>"; };
 		17DFDE86251D309400A25F31 /* OpenSans-License.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "OpenSans-License.txt"; sourceTree = "<group>"; };
+		17E5DF892543610700DCDC9B /* PostTextEditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTextEditingView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -300,6 +302,7 @@
 			isa = PBXGroup;
 			children = (
 				17A67CAE251A5DD7002F163D /* PostEditorView.swift */,
+				17E5DF892543610700DCDC9B /* PostTextEditingView.swift */,
 			);
 			path = PostEditor;
 			sourceTree = "<group>";
@@ -733,6 +736,7 @@
 				17480CA6251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */,
 				17C42E662509237800072984 /* PostListFilteredView.swift in Sources */,
 				17120DAD24E1B99F002B9F6C /* AccountLoginView.swift in Sources */,
+				17E5DF8A2543610700DCDC9B /* PostTextEditingView.swift in Sources */,
 				17C42E71250AAFD500072984 /* NSManagedObjectContext+ExecuteAndMergeChanges.swift in Sources */,
 				1756AE7B24CB65DF00FD7257 /* PostListView.swift in Sources */,
 				1753F6AC24E431CC00309365 /* MacPreferencesView.swift in Sources */,

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		171BFDFA24D4AF8300888236 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171BFDF924D4AF8300888236 /* CollectionListView.swift */; };
 		171BFDFB24D4AF8300888236 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171BFDF924D4AF8300888236 /* CollectionListView.swift */; };
 		173E19D1254318F600440F0F /* RemoteChangePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173E19D0254318F600440F0F /* RemoteChangePromptView.swift */; };
+		173E19E3254329CC00440F0F /* PostTextEditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173E19E2254329CC00440F0F /* PostTextEditingView.swift */; };
 		17480CA5251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */; };
 		17480CA6251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */; };
 		174D313224EC2831006CA9EE /* WriteFreelyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174D313124EC2831006CA9EE /* WriteFreelyModel.swift */; };
@@ -44,7 +45,6 @@
 		1756DC0224FEE18400207AB8 /* WFACollection+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756DBFF24FEE18400207AB8 /* WFACollection+CoreDataClass.swift */; };
 		1756DC0324FEE18400207AB8 /* WFACollection+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756DC0024FEE18400207AB8 /* WFACollection+CoreDataProperties.swift */; };
 		1756DC0424FEE18400207AB8 /* WFACollection+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1756DC0024FEE18400207AB8 /* WFACollection+CoreDataProperties.swift */; };
-		17582194251A4E53004FC441 /* UITextView+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17582193251A4E53004FC441 /* UITextView+Appearance.swift */; };
 		1765F62A24E18EA200C9EBF0 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1765F62924E18EA200C9EBF0 /* SidebarView.swift */; };
 		1765F62B24E18EA200C9EBF0 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1765F62924E18EA200C9EBF0 /* SidebarView.swift */; };
 		17681E412519410E00D394AE /* UINavigationController+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17681E402519410E00D394AE /* UINavigationController+Appearance.swift */; };
@@ -119,6 +119,7 @@
 		17120DB124E1E19C002B9F6C /* SettingsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
 		171BFDF924D4AF8300888236 /* CollectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionListView.swift; sourceTree = "<group>"; };
 		173E19D0254318F600440F0F /* RemoteChangePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteChangePromptView.swift; sourceTree = "<group>"; };
+		173E19E2254329CC00440F0F /* PostTextEditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTextEditingView.swift; sourceTree = "<group>"; };
 		17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppVersion.swift"; sourceTree = "<group>"; };
 		174D313124EC2831006CA9EE /* WriteFreelyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteFreelyModel.swift; sourceTree = "<group>"; };
 		1753F6AB24E431CC00309365 /* MacPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacPreferencesView.swift; sourceTree = "<group>"; };
@@ -132,7 +133,6 @@
 		1756DBB924FED45500207AB8 /* LocalStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalStorageManager.swift; sourceTree = "<group>"; };
 		1756DBFF24FEE18400207AB8 /* WFACollection+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WFACollection+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
 		1756DC0024FEE18400207AB8 /* WFACollection+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WFACollection+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
-		17582193251A4E53004FC441 /* UITextView+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+Appearance.swift"; sourceTree = "<group>"; };
 		1765F62924E18EA200C9EBF0 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		17681E402519410E00D394AE /* UINavigationController+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Appearance.swift"; sourceTree = "<group>"; };
 		17A5388724DDA31F00DEFF9A /* MacAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAccountView.swift; sourceTree = "<group>"; };
@@ -273,7 +273,6 @@
 			children = (
 				1756AE8024CB844500FD7257 /* View+Keyboard.swift */,
 				17681E402519410E00D394AE /* UINavigationController+Appearance.swift */,
-				17582193251A4E53004FC441 /* UITextView+Appearance.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -292,6 +291,7 @@
 			children = (
 				1756AE7624CB2EDD00FD7257 /* PostEditorView.swift */,
 				173E19D0254318F600440F0F /* RemoteChangePromptView.swift */,
+				173E19E2254329CC00440F0F /* PostTextEditingView.swift */,
 			);
 			path = PostEditor;
 			sourceTree = "<group>";
@@ -699,7 +699,6 @@
 				17B996DA2502D23E0017B536 /* WFAPost+CoreDataProperties.swift in Sources */,
 				1756AE7724CB2EDD00FD7257 /* PostEditorView.swift in Sources */,
 				17DF32D524C8CA3400BCE2E3 /* PostStatusBadgeView.swift in Sources */,
-				17582194251A4E53004FC441 /* UITextView+Appearance.swift in Sources */,
 				17D435E824E3128F0036B539 /* PreferencesModel.swift in Sources */,
 				1765F62A24E18EA200C9EBF0 /* SidebarView.swift in Sources */,
 				1756AE7A24CB65DF00FD7257 /* PostListView.swift in Sources */,
@@ -711,6 +710,7 @@
 				17120DA224E1985C002B9F6C /* AccountModel.swift in Sources */,
 				17120DA324E19A42002B9F6C /* PreferencesView.swift in Sources */,
 				1756AE6E24CB255B00FD7257 /* PostListModel.swift in Sources */,
+				173E19E3254329CC00440F0F /* PostTextEditingView.swift in Sources */,
 				174D313224EC2831006CA9EE /* WriteFreelyModel.swift in Sources */,
 				17C42E70250AA12300072984 /* NSManagedObjectContext+ExecuteAndMergeChanges.swift in Sources */,
 				17120DA124E19839002B9F6C /* AccountView.swift in Sources */,

--- a/iOS/Extensions/UITextView+Appearance.swift
+++ b/iOS/Extensions/UITextView+Appearance.swift
@@ -1,9 +1,0 @@
-import UIKit
-
-extension UITextView {
-    override open func draw(_ rect: CGRect) {
-        super.draw(rect)
-        let appearance = UITextView.appearance()
-        appearance.backgroundColor = .clear
-    }
-}

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct PostEditorView: View {
-    private let bodyLineSpacing: CGFloat = 17 * 0.5
     @EnvironmentObject var model: WriteFreelyModel
     @Environment(\.managedObjectContext) var moc
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
@@ -36,104 +35,11 @@ struct PostEditorView: View {
                     }
                 )
             }
-            switch post.appearance {
-            case "sans":
-                TextField("Title (optional)", text: $post.title)
-                    .padding(.horizontal, 4)
-                    .font(.custom("OpenSans-Regular", size: 26, relativeTo: Font.TextStyle.largeTitle))
-                    .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
-                            post.status = PostStatus.edited.rawValue
-                        }
-                        if updatingTitleFromServer {
-                            updatingTitleFromServer = false
-                        }
-                    }
-                ZStack(alignment: .topLeading) {
-                    if post.body.count == 0 {
-                        Text("Write...")
-                            .foregroundColor(Color(UIColor.placeholderText))
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 8)
-                            .font(.custom("OpenSans-Regular", size: 17, relativeTo: Font.TextStyle.body))
-                    }
-                    TextEditor(text: $post.body)
-                        .font(.custom("OpenSans-Regular", size: 17, relativeTo: Font.TextStyle.body))
-                        .lineSpacing(bodyLineSpacing)
-                        .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
-                                post.status = PostStatus.edited.rawValue
-                            }
-                            if updatingBodyFromServer {
-                                updatingBodyFromServer = false
-                            }
-                    }
-                }
-            case "wrap", "mono", "code":
-                TextField("Title (optional)", text: $post.title)
-                    .padding(.horizontal, 4)
-                    .font(.custom("Hack", size: 26, relativeTo: Font.TextStyle.largeTitle))
-                    .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
-                            post.status = PostStatus.edited.rawValue
-                        }
-                        if updatingTitleFromServer {
-                            updatingTitleFromServer = false
-                        }
-                    }
-                ZStack(alignment: .topLeading) {
-                    if post.body.count == 0 {
-                        Text("Write...")
-                            .foregroundColor(Color(UIColor.placeholderText))
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 8)
-                            .font(.custom("Hack", size: 17, relativeTo: Font.TextStyle.body))
-                    }
-                    TextEditor(text: $post.body)
-                        .font(.custom("Hack", size: 17, relativeTo: Font.TextStyle.body))
-                        .lineSpacing(bodyLineSpacing)
-                        .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
-                                post.status = PostStatus.edited.rawValue
-                            }
-                            if updatingBodyFromServer {
-                                updatingBodyFromServer = false
-                            }
-                    }
-                }
-            default:
-                TextField("Title (optional)", text: $post.title)
-                    .padding(.horizontal, 4)
-                    .font(.custom("Lora", size: 26, relativeTo: Font.TextStyle.largeTitle))
-                    .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
-                            post.status = PostStatus.edited.rawValue
-                        }
-                        if updatingTitleFromServer {
-                            updatingTitleFromServer = false
-                        }
-                    }
-                ZStack(alignment: .topLeading) {
-                    if post.body.count == 0 {
-                        Text("Write...")
-                            .foregroundColor(Color(UIColor.placeholderText))
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 8)
-                            .font(.custom("Lora", size: 17, relativeTo: Font.TextStyle.body))
-                    }
-                    TextEditor(text: $post.body)
-                        .font(.custom("Lora", size: 17, relativeTo: Font.TextStyle.body))
-                        .lineSpacing(bodyLineSpacing)
-                        .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
-                                post.status = PostStatus.edited.rawValue
-                            }
-                            if updatingBodyFromServer {
-                                updatingBodyFromServer = false
-                            }
-                    }
-                }
-            }
+            PostTextEditingView(
+                post: _post,
+                updatingTitleFromServer: $updatingTitleFromServer,
+                updatingBodyFromServer: $updatingBodyFromServer
+            )
         }
         .navigationBarTitleDisplayMode(.inline)
         .padding()

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -21,38 +21,20 @@ struct PostEditorView: View {
     var body: some View {
         VStack {
             if post.hasNewerRemoteCopy {
-                HStack {
-                    Text("⚠️ Newer copy on server. Replace local copy?")
-                        .font(horizontalSizeClass == .compact ? .caption : .body)
-                        .foregroundColor(.secondary)
-                    Button(action: {
-                        model.updateFromServer(post: post)
-                    }, label: {
-                        Image(systemName: "square.and.arrow.down")
-                    })
-                }
-                .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
-                .background(Color(UIColor.secondarySystemBackground))
-                .clipShape(Capsule())
-                .padding(.bottom)
+                RemoteChangePromptView(
+                    remoteChangeType: .remoteCopyUpdated,
+                    buttonHandler: { model.updateFromServer(post: post) }
+                )
             } else if post.wasDeletedFromServer {
-                HStack {
-                    Text("⚠️ Post deleted from server. Delete local copy?")
-                        .font(horizontalSizeClass == .compact ? .caption : .body)
-                        .foregroundColor(.secondary)
-                    Button(action: {
+                RemoteChangePromptView(
+                    remoteChangeType: .remoteCopyDeleted,
+                    buttonHandler: {
                         self.presentationMode.wrappedValue.dismiss()
                         DispatchQueue.main.async {
                             model.posts.remove(post)
                         }
-                    }, label: {
-                        Image(systemName: "trash")
-                    })
-                }
-                .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
-                .background(Color(UIColor.secondarySystemBackground))
-                .clipShape(Capsule())
-                .padding(.bottom)
+                    }
+                )
             }
             switch post.appearance {
             case "sans":

--- a/iOS/PostEditor/PostTextEditingView.swift
+++ b/iOS/PostEditor/PostTextEditingView.swift
@@ -7,6 +7,7 @@ enum PostAppearance: String {
 }
 
 struct PostTextEditingView: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @ObservedObject var post: WFAPost
     @Binding var updatingTitleFromServer: Bool
     @Binding var updatingBodyFromServer: Bool
@@ -44,7 +45,7 @@ struct PostTextEditingView: View {
                 }
                 TextEditor(text: $post.body)
                     .font(.custom(appearance.rawValue, size: 17, relativeTo: .body))
-                    .lineSpacing(17 * bodyLineSpacingMultiplier)
+                    .lineSpacing(17 * (horizontalSizeClass == .compact ? 0.25 : bodyLineSpacingMultiplier))
                     .onChange(of: post.body) { _ in
                         if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                             post.status = PostStatus.edited.rawValue

--- a/iOS/PostEditor/PostTextEditingView.swift
+++ b/iOS/PostEditor/PostTextEditingView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+enum PostAppearance: String {
+    case sans = "OpenSans-Regular"
+    case mono = "Hack"
+    case serif = "Lora"
+}
+
+struct PostTextEditingView: View {
+    @ObservedObject var post: WFAPost
+    @Binding var updatingTitleFromServer: Bool
+    @Binding var updatingBodyFromServer: Bool
+    @State private var appearance: PostAppearance = .serif
+    private let bodyLineSpacingMultiplier: CGFloat = 0.5
+
+    init(
+        post: ObservedObject<WFAPost>,
+        updatingTitleFromServer: Binding<Bool>,
+        updatingBodyFromServer: Binding<Bool>
+    ) {
+        self._post = post
+        self._updatingTitleFromServer = updatingTitleFromServer
+        self._updatingBodyFromServer = updatingBodyFromServer
+        UITextView.appearance().backgroundColor = .clear
+    }
+
+    var body: some View {
+        VStack {
+            TextField("Title (optional)", text: $post.title)
+                .font(.custom(appearance.rawValue, size: 26, relativeTo: .largeTitle))
+                .padding(.horizontal, 4)
+                .onChange(of: post.title) { _ in
+                    if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
+                        post.status = PostStatus.edited.rawValue
+                    }
+                }
+            ZStack(alignment: .topLeading) {
+                if post.body.count == 0 {
+                    Text("Write…")
+                        .font(.custom(appearance.rawValue, size: 17, relativeTo: .body))
+                        .foregroundColor(Color(UIColor.placeholderText))
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 8)
+                }
+                TextEditor(text: $post.body)
+                    .font(.custom(appearance.rawValue, size: 17, relativeTo: .body))
+                    .lineSpacing(17 * bodyLineSpacingMultiplier)
+                    .onChange(of: post.body) { _ in
+                        if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
+                            post.status = PostStatus.edited.rawValue
+                        }
+                        if updatingBodyFromServer {
+                            updatingBodyFromServer = false
+                        }
+                    }
+            }
+        }
+        .onAppear(perform: {
+            switch post.appearance {
+            case "sans":
+                self.appearance = .sans
+            case "wrap", "mono", "code":
+                self.appearance = .mono
+            default:
+                self.appearance = .serif
+            }
+        })
+    }
+}

--- a/iOS/PostEditor/RemoteChangePromptView.swift
+++ b/iOS/PostEditor/RemoteChangePromptView.swift
@@ -6,7 +6,6 @@ enum RemotePostChangeType {
 }
 
 struct RemoteChangePromptView: View {
-    @EnvironmentObject var model: WriteFreelyModel
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @State private var promptText: String = "This is placeholder prompt text. Replace it?"
     @State private var promptIcon: Image = Image(systemName: "questionmark.square.dashed")

--- a/iOS/PostEditor/RemoteChangePromptView.swift
+++ b/iOS/PostEditor/RemoteChangePromptView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+enum RemotePostChangeType {
+    case remoteCopyUpdated
+    case remoteCopyDeleted
+}
+
+struct RemoteChangePromptView: View {
+    @EnvironmentObject var model: WriteFreelyModel
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @State private var promptText: String = "This is placeholder prompt text. Replace it?"
+    @State private var promptIcon: Image = Image(systemName: "questionmark.square.dashed")
+    @State var remoteChangeType: RemotePostChangeType
+    @State var buttonHandler: () -> Void
+
+    var body: some View {
+        HStack {
+            Text("⚠️ \(promptText)")
+                .font(horizontalSizeClass == .compact ? .caption : .body)
+                .foregroundColor(.secondary)
+            Button(action: buttonHandler, label: { promptIcon })
+        }
+        .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
+        .background(Color(UIColor.secondarySystemBackground))
+        .clipShape(Capsule())
+        .padding(.bottom)
+        .onAppear(perform: {
+            switch remoteChangeType {
+            case .remoteCopyUpdated:
+                promptText = "Newer copy on server. Replace local copy?"
+                promptIcon = Image(systemName: "square.and.arrow.down")
+            case .remoteCopyDeleted:
+                promptText = "Post deleted from server. Delete local copy?"
+                promptIcon = Image(systemName: "trash")
+            }
+        })
+    }
+}
+
+struct RemoteChangePromptView_UpdatedPreviews: PreviewProvider {
+    static var previews: some View {
+        RemoteChangePromptView(
+            remoteChangeType: .remoteCopyUpdated,
+            buttonHandler: { print("Hello, updated post!") }
+        )
+    }
+}
+
+struct RemoteChangePromptView_DeletedPreviews: PreviewProvider {
+    static var previews: some View {
+        RemoteChangePromptView(
+            remoteChangeType: .remoteCopyDeleted,
+            buttonHandler: { print("Goodbye, deleted post!") }
+        )
+    }
+}

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -10,129 +10,12 @@ struct PostEditorView: View {
     @State private var updatingBodyFromServer: Bool = false
 
     var body: some View {
-        VStack {
-            switch post.appearance {
-            case "sans":
-                TextField("Title (optional)", text: $post.title)
-                    .textFieldStyle(PlainTextFieldStyle())
-                    .padding(.horizontal, 4)
-                    .padding(.bottom)
-                    .font(.custom("OpenSans-Regular", size: 26, relativeTo: Font.TextStyle.largeTitle))
-                    .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
-                            post.status = PostStatus.edited.rawValue
-                        }
-                        if updatingTitleFromServer {
-                            updatingTitleFromServer = false
-                        }
-                    }
-                ZStack(alignment: .topLeading) {
-                    if post.body.count == 0 {
-                        Text("Write...")
-                            .foregroundColor(Color(NSColor.placeholderTextColor))
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 2)
-                            .font(.custom("OpenSans-Regular", size: 17, relativeTo: Font.TextStyle.body))
-                    }
-                    TextEditor(text: $post.body)
-                        .font(.custom("OpenSans-Regular", size: 17, relativeTo: Font.TextStyle.body))
-                        .lineSpacing(bodyLineSpacing)
-                        .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
-                        .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
-                                post.status = PostStatus.edited.rawValue
-                            }
-                            if updatingBodyFromServer {
-                                updatingBodyFromServer = false
-                            }
-                        }
-                        .onHover(perform: { hovering in
-                            self.isHovering = hovering
-                        })
-                }
-                .background(Color(NSColor.controlBackgroundColor))
-            case "wrap", "mono", "code":
-                TextField("Title (optional)", text: $post.title)
-                    .textFieldStyle(PlainTextFieldStyle())
-                    .padding(.horizontal, 4)
-                    .padding(.bottom)
-                    .font(.custom("Hack", size: 26, relativeTo: Font.TextStyle.largeTitle))
-                    .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
-                            post.status = PostStatus.edited.rawValue
-                        }
-                        if updatingTitleFromServer {
-                            updatingTitleFromServer = false
-                        }
-                    }
-                ZStack(alignment: .topLeading) {
-                    if post.body.count == 0 {
-                        Text("Write...")
-                            .foregroundColor(Color(NSColor.placeholderTextColor))
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 2)
-                            .font(.custom("Hack", size: 17, relativeTo: Font.TextStyle.body))
-                    }
-                    TextEditor(text: $post.body)
-                        .font(.custom("Hack", size: 17, relativeTo: Font.TextStyle.body))
-                        .lineSpacing(bodyLineSpacing)
-                        .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
-                        .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
-                                post.status = PostStatus.edited.rawValue
-                            }
-                            if updatingBodyFromServer {
-                                updatingBodyFromServer = false
-                            }
-                        }
-                        .onHover(perform: { hovering in
-                            self.isHovering = hovering
-                        })
-                }
-                .background(Color(NSColor.controlBackgroundColor))
-            default:
-                TextField("Title (optional)", text: $post.title)
-                    .textFieldStyle(PlainTextFieldStyle())
-                    .padding(.horizontal, 4)
-                    .padding(.bottom)
-                    .font(.custom("Lora", size: 26, relativeTo: Font.TextStyle.largeTitle))
-                    .onChange(of: post.title) { _ in
-                        if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
-                            post.status = PostStatus.edited.rawValue
-                        }
-                        if updatingTitleFromServer {
-                            updatingTitleFromServer = false
-                        }
-                    }
-                ZStack(alignment: .topLeading) {
-                    if post.body.count == 0 {
-                        Text("Write...")
-                            .foregroundColor(Color(NSColor.placeholderTextColor))
-                            .padding(.horizontal, 4)
-                            .padding(.vertical, 2)
-                            .font(.custom("Lora", size: 17, relativeTo: Font.TextStyle.body))
-                    }
-                    TextEditor(text: $post.body)
-                        .font(.custom("Lora", size: 17, relativeTo: Font.TextStyle.body))
-                        .lineSpacing(bodyLineSpacing)
-                        .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
-                        .onChange(of: post.body) { _ in
-                            if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
-                                post.status = PostStatus.edited.rawValue
-                            }
-                            if updatingBodyFromServer {
-                                updatingBodyFromServer = false
-                            }
-                        }
-                        .onHover(perform: { hovering in
-                            self.isHovering = hovering
-                        })
-                }
-                .background(Color(NSColor.controlBackgroundColor))
-            }
-        }
+        PostTextEditingView(
+            post: post,
+            updatingTitleFromServer: $updatingTitleFromServer,
+            updatingBodyFromServer: $updatingBodyFromServer
+        )
         .padding()
-        .background(Color.white)
         .toolbar {
             ToolbarItem(placement: .status) {
                 PostEditorStatusToolbarView(post: post)
@@ -150,7 +33,7 @@ struct PostEditorView: View {
                 }, label: {
                     Image(systemName: "paperplane")
                 })
-                .disabled(post.status == PostStatus.published.rawValue || || post.body.count == 0)
+                .disabled(post.status == PostStatus.published.rawValue || post.body.count == 0)
             }
         }
         .onChange(of: post.hasNewerRemoteCopy, perform: { _ in


### PR DESCRIPTION
Closes #108.

This PR also includes a tweak to use a slightly smaller line spacing value in the compact horizontal size class, to compensate for the smaller editing area when the app is running on iPhone or in slide-over mode on iPad, as discussed in #111.