### PR TITLE
Implement responder chain in editor

### DIFF
--- a/Shared/PostEditor/PostEditorModel.swift
+++ b/Shared/PostEditor/PostEditorModel.swift
@@ -3,8 +3,8 @@ import CoreData
 
 enum PostAppearance: String {
     case sans = "OpenSans-Regular"
-    case mono = "Hack"
-    case serif = "Lora"
+    case mono = "Hack-Regular"
+    case serif = "Lora-Regular"
 }
 
 struct PostEditorModel {

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		17A5388F24DDEC7400DEFF9A /* AccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5388D24DDEC7400DEFF9A /* AccountView.swift */; };
 		17A5389324DDED0000DEFF9A /* PreferencesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5389124DDED0000DEFF9A /* PreferencesView.swift */; };
 		17A67CAF251A5DD7002F163D /* PostEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A67CAE251A5DD7002F163D /* PostEditorView.swift */; };
+		17AD0A5E25489E810057D763 /* PostTitleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AD0A5D25489E810057D763 /* PostTitleTextView.swift */; };
+		17AD0A6425489E900057D763 /* PostBodyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AD0A6325489E900057D763 /* PostBodyTextView.swift */; };
 		17B3E965250FAA9000EE9748 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 17B3E964250FAA9000EE9748 /* LaunchScreen.storyboard */; };
 		17B5103B2515448D00E9631F /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 17B5103A2515448D00E9631F /* Credits.rtf */; };
 		17B996D82502D23E0017B536 /* WFAPost+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B996D62502D23E0017B536 /* WFAPost+CoreDataClass.swift */; };
@@ -141,6 +143,8 @@
 		17A5388D24DDEC7400DEFF9A /* AccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountView.swift; sourceTree = "<group>"; };
 		17A5389124DDED0000DEFF9A /* PreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesView.swift; sourceTree = "<group>"; };
 		17A67CAE251A5DD7002F163D /* PostEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorView.swift; sourceTree = "<group>"; };
+		17AD0A5D25489E810057D763 /* PostTitleTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTitleTextView.swift; sourceTree = "<group>"; };
+		17AD0A6325489E900057D763 /* PostBodyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostBodyTextView.swift; sourceTree = "<group>"; };
 		17B3E964250FAA9000EE9748 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		17B5103A2515448D00E9631F /* Credits.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 		17B996D62502D23E0017B536 /* WFAPost+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WFAPost+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
@@ -294,6 +298,8 @@
 				1756AE7624CB2EDD00FD7257 /* PostEditorView.swift */,
 				173E19D0254318F600440F0F /* RemoteChangePromptView.swift */,
 				173E19E2254329CC00440F0F /* PostTextEditingView.swift */,
+				17AD0A5D25489E810057D763 /* PostTitleTextView.swift */,
+				17AD0A6325489E900057D763 /* PostBodyTextView.swift */,
 			);
 			path = PostEditor;
 			sourceTree = "<group>";
@@ -694,6 +700,8 @@
 				170DFA34251BBC44001D82A0 /* PostEditorModel.swift in Sources */,
 				17120DAC24E1B99F002B9F6C /* AccountLoginView.swift in Sources */,
 				17480CA5251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */,
+				17AD0A6425489E900057D763 /* PostBodyTextView.swift in Sources */,
+				17AD0A5E25489E810057D763 /* PostTitleTextView.swift in Sources */,
 				17120DA924E1B2F5002B9F6C /* AccountLogoutView.swift in Sources */,
 				171BFDFA24D4AF8300888236 /* CollectionListView.swift in Sources */,
 				1756DBB324FECDBB00207AB8 /* PostEditorStatusToolbarView.swift in Sources */,

--- a/iOS/PostEditor/PostBodyTextView.swift
+++ b/iOS/PostEditor/PostBodyTextView.swift
@@ -34,7 +34,20 @@ class PostBodyCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate
         lineSpacingAfterGlyphAt glyphIndex: Int,
         withProposedLineFragmentRect rect: CGRect
     ) -> CGFloat {
-        return 17 * lineSpacingMultiplier
+        // HACK: - This seems to be the only way to get line spacing to update dynamically on iPad
+        //         when switching between full-screen, split-screen, and slide-over views.
+        if let window = UIApplication.shared.windows.filter({ $0.isKeyWindow }).first {
+            // Get the width of the window to determine the size class
+            if window.frame.width < 600 {
+                // Use 0.25 multiplier for compact size class
+                return 17 * 0.25
+            } else {
+                // Use 0.5 multiplier otherwise
+                return 17 * 0.5
+            }
+        } else {
+            return 17 * lineSpacingMultiplier
+        }
     }
 }
 
@@ -42,7 +55,7 @@ struct PostBodyTextView: UIViewRepresentable {
     @Binding var text: String
     @Binding var textStyle: UIFont
     @Binding var isFirstResponder: Bool
-    var lineSpacing: CGFloat
+    @State var lineSpacing: CGFloat
 
     func makeUIView(context: UIViewRepresentableContext<PostBodyTextView>) -> UITextView {
         let textView = UITextView(frame: .zero)

--- a/iOS/PostEditor/PostBodyTextView.swift
+++ b/iOS/PostEditor/PostBodyTextView.swift
@@ -1,0 +1,20 @@
+//
+//  PostBodyTextView.swift
+//  WriteFreely-MultiPlatform (iOS)
+//
+//  Created by Angelo Stavrow on 2020-10-27.
+//
+
+import SwiftUI
+
+struct PostBodyTextView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct PostBodyTextView_Previews: PreviewProvider {
+    static var previews: some View {
+        PostBodyTextView()
+    }
+}

--- a/iOS/PostEditor/PostBodyTextView.swift
+++ b/iOS/PostEditor/PostBodyTextView.swift
@@ -24,6 +24,7 @@ struct PostBodyTextView: UIViewRepresentable {
     @Binding var text: String
     @Binding var textStyle: UIFont
     @Binding var isFirstResponder: Bool
+    var lineSpacing: CGFloat
 
     func makeUIView(context: UIViewRepresentableContext<PostBodyTextView>) -> UITextView {
         let textView = UITextView(frame: .zero)
@@ -40,7 +41,16 @@ struct PostBodyTextView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: UITextView, context: UIViewRepresentableContext<PostBodyTextView>) {
-        uiView.text = text
+        let attributedString = NSMutableAttributedString(string: text)
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineSpacing = lineSpacing
+        attributedString.addAttribute(
+            NSAttributedString.Key.paragraphStyle,
+            value: paragraphStyle,
+            range: NSMakeRange(0, attributedString.length) // swiftlint:disable:this legacy_constructor
+        )
+
+        uiView.attributedText = attributedString
         let font = textStyle
         let fontMetrics = UIFontMetrics(forTextStyle: .largeTitle)
         uiView.font = fontMetrics.scaledFont(for: font)

--- a/iOS/PostEditor/PostBodyTextView.swift
+++ b/iOS/PostEditor/PostBodyTextView.swift
@@ -1,20 +1,54 @@
-//
-//  PostBodyTextView.swift
-//  WriteFreely-MultiPlatform (iOS)
-//
-//  Created by Angelo Stavrow on 2020-10-27.
-//
+// Based on https://stackoverflow.com/a/56508132/1234545
 
 import SwiftUI
 
-struct PostBodyTextView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
-    }
-}
+struct PostBodyTextView: UIViewRepresentable {
 
-struct PostBodyTextView_Previews: PreviewProvider {
-    static var previews: some View {
-        PostBodyTextView()
+    class Coordinator: NSObject, UITextViewDelegate {
+        @Binding var text: String
+        @Binding var isFirstResponder: Bool
+        var didBecomeFirstResponder: Bool = false
+
+        init(text: Binding<String>, isFirstResponder: Binding<Bool>) {
+            _text = text
+            _isFirstResponder = isFirstResponder
+        }
+
+        func textViewDidChangeSelection(_ textView: UITextView) {
+            DispatchQueue.main.async {
+                self.text = textView.text ?? ""
+            }
+        }
+    }
+
+    @Binding var text: String
+    @Binding var textStyle: UIFont
+    @Binding var isFirstResponder: Bool
+
+    func makeUIView(context: UIViewRepresentableContext<PostBodyTextView>) -> UITextView {
+        let textView = UITextView(frame: .zero)
+        textView.delegate = context.coordinator
+        let font = textStyle
+        let fontMetrics = UIFontMetrics(forTextStyle: .largeTitle)
+        textView.font = fontMetrics.scaledFont(for: font)
+        textView.backgroundColor = UIColor.clear
+        return textView
+    }
+
+    func makeCoordinator() -> PostBodyTextView.Coordinator {
+        return Coordinator(text: $text, isFirstResponder: $isFirstResponder)
+    }
+
+    func updateUIView(_ uiView: UITextView, context: UIViewRepresentableContext<PostBodyTextView>) {
+        uiView.text = text
+        let font = textStyle
+        let fontMetrics = UIFontMetrics(forTextStyle: .largeTitle)
+        uiView.font = fontMetrics.scaledFont(for: font)
+
+        // We don't want the text field to become first responder every time SwiftUI refreshes the view.
+        if isFirstResponder && !context.coordinator.didBecomeFirstResponder {
+            uiView.becomeFirstResponder()
+            context.coordinator.didBecomeFirstResponder = true
+        }
     }
 }

--- a/iOS/PostEditor/PostEditorView.swift
+++ b/iOS/PostEditor/PostEditorView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct PostEditorView: View {
     @EnvironmentObject var model: WriteFreelyModel
     @Environment(\.managedObjectContext) var moc
-    @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.presentationMode) var presentationMode
 
     @ObservedObject var post: WFAPost

--- a/iOS/PostEditor/PostTextEditingView.swift
+++ b/iOS/PostEditor/PostTextEditingView.swift
@@ -11,6 +11,7 @@ struct PostTextEditingView: View {
     @State private var titleIsFirstResponder: Bool = true
     @State private var bodyTextStyle: UIFont = UIFont(name: "Lora-Regular", size: 17)!
     @State private var bodyIsFirstResponder: Bool = false
+    @State private var bodyCursorPosition: UITextRange?
     private let lineSpacingMultiplier: CGFloat = 0.5
 
     init(
@@ -71,6 +72,7 @@ struct PostTextEditingView: View {
                     text: $post.body,
                     textStyle: $bodyTextStyle,
                     isFirstResponder: $bodyIsFirstResponder,
+                    currentTextPosition: $bodyCursorPosition,
                     lineSpacing: horizontalSizeClass == .compact ? lineSpacingMultiplier / 2 : lineSpacingMultiplier
                 )
                 .onChange(of: post.body) { _ in

--- a/iOS/PostEditor/PostTextEditingView.swift
+++ b/iOS/PostEditor/PostTextEditingView.swift
@@ -46,7 +46,8 @@ struct PostTextEditingView: View {
                     text: $post.title,
                     textStyle: $titleTextStyle,
                     height: $titleTextHeight,
-                    isFirstResponder: $titleIsFirstResponder
+                    isFirstResponder: $titleIsFirstResponder,
+                    lineSpacing: horizontalSizeClass == .compact ? lineSpacingMultiplier / 2 : lineSpacingMultiplier
                 )
                 .frame(height: titleFieldHeight)
                 .onChange(of: post.title) { _ in

--- a/iOS/PostEditor/PostTextEditingView.swift
+++ b/iOS/PostEditor/PostTextEditingView.swift
@@ -70,9 +70,9 @@ struct PostTextEditingView: View {
                     text: $post.body,
                     textStyle: $bodyTextStyle,
                     isFirstResponder: $bodyIsFirstResponder,
-                    lineSpacing: 17 * (
-                        horizontalSizeClass == .compact ? bodyLineSpacingMultiplier / 2 : bodyLineSpacingMultiplier
-                    )
+                    lineSpacing: horizontalSizeClass == .compact
+                        ? bodyLineSpacingMultiplier / 2
+                        : bodyLineSpacingMultiplier
                 )
                 .onChange(of: post.body) { _ in
                     if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {

--- a/iOS/PostEditor/PostTextEditingView.swift
+++ b/iOS/PostEditor/PostTextEditingView.swift
@@ -11,7 +11,7 @@ struct PostTextEditingView: View {
     @State private var titleIsFirstResponder: Bool = true
     @State private var bodyTextStyle: UIFont = UIFont(name: "Lora-Regular", size: 17)!
     @State private var bodyIsFirstResponder: Bool = false
-    private let bodyLineSpacingMultiplier: CGFloat = 0.5
+    private let lineSpacingMultiplier: CGFloat = 0.5
 
     init(
         post: ObservedObject<WFAPost>,
@@ -70,9 +70,7 @@ struct PostTextEditingView: View {
                     text: $post.body,
                     textStyle: $bodyTextStyle,
                     isFirstResponder: $bodyIsFirstResponder,
-                    lineSpacing: horizontalSizeClass == .compact
-                        ? bodyLineSpacingMultiplier / 2
-                        : bodyLineSpacingMultiplier
+                    lineSpacing: horizontalSizeClass == .compact ? lineSpacingMultiplier / 2 : lineSpacingMultiplier
                 )
                 .onChange(of: post.body) { _ in
                     if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {

--- a/iOS/PostEditor/PostTitleTextView.swift
+++ b/iOS/PostEditor/PostTitleTextView.swift
@@ -1,20 +1,95 @@
-//
-//  PostTitleTextView.swift
-//  WriteFreely-MultiPlatform (iOS)
-//
-//  Created by Angelo Stavrow on 2020-10-27.
-//
+// Based on https://lostmoa.com/blog/DynamicHeightForTextFieldInSwiftUI/
+// and https://stackoverflow.com/a/56508132/1234545
 
 import SwiftUI
 
-struct PostTitleTextView: View {
-    var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+class Coordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate {
+    @Binding var text: String
+    @Binding var isFirstResponder: Bool
+    var didBecomeFirstResponder: Bool = false
+    var postTitleTextView: PostTitleTextView
+
+    weak var textView: UITextView?
+
+    init(_ textView: PostTitleTextView, text: Binding<String>, isFirstResponder: Binding<Bool>) {
+        self.postTitleTextView = textView
+        _text = text
+        _isFirstResponder = isFirstResponder
+    }
+
+    func textViewDidChangeSelection(_ textView: UITextView) {
+        DispatchQueue.main.async {
+            self.postTitleTextView.text = textView.text ?? ""
+        }
+    }
+
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        if (text == "\n") {
+            self.isFirstResponder.toggle()
+            return false
+        }
+        return true
+    }
+
+    func layoutManager(
+        _ layoutManager: NSLayoutManager,
+        didCompleteLayoutFor textContainer: NSTextContainer?,
+        atEnd layoutFinishedFlag: Bool
+    ) {
+        DispatchQueue.main.async {
+            guard let view = self.textView else {
+                return
+            }
+            let size = view.sizeThatFits(view.bounds.size)
+            if self.postTitleTextView.height != size.height {
+                self.postTitleTextView.height = size.height
+            }
+        }
     }
 }
 
-struct PostTitleTextView_Previews: PreviewProvider {
-    static var previews: some View {
-        PostTitleTextView()
+struct PostTitleTextView: UIViewRepresentable {
+    @Binding var text: String
+    @Binding var textStyle: UIFont
+    @Binding var height: CGFloat
+    @Binding var isFirstResponder: Bool
+
+    func makeUIView(context: UIViewRepresentableContext<PostTitleTextView>) -> UITextView {
+        let textView = UITextView()
+
+        textView.isEditable = true
+        textView.isUserInteractionEnabled = true
+        textView.isScrollEnabled = true
+        textView.alwaysBounceVertical = false
+
+        context.coordinator.textView = textView
+        textView.delegate = context.coordinator
+        textView.layoutManager.delegate = context.coordinator
+
+        let font = textStyle
+        let fontMetrics = UIFontMetrics(forTextStyle: .largeTitle)
+        textView.font = fontMetrics.scaledFont(for: font)
+
+        textView.backgroundColor = UIColor.clear
+
+        return textView
+    }
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(self, text: $text, isFirstResponder: $isFirstResponder)
+    }
+
+    func updateUIView(_ uiView: UITextView, context: UIViewRepresentableContext<PostTitleTextView>) {
+        uiView.text = text
+
+        let font = textStyle
+        let fontMetrics = UIFontMetrics(forTextStyle: .largeTitle)
+        uiView.font = fontMetrics.scaledFont(for: font)
+
+        // We don't want the text field to become first responder every time SwiftUI refreshes the view.
+        if isFirstResponder && !context.coordinator.didBecomeFirstResponder {
+            uiView.becomeFirstResponder()
+            context.coordinator.didBecomeFirstResponder = true
+        }
     }
 }

--- a/iOS/PostEditor/PostTitleTextView.swift
+++ b/iOS/PostEditor/PostTitleTextView.swift
@@ -1,5 +1,4 @@
-// Based on https://lostmoa.com/blog/DynamicHeightForTextFieldInSwiftUI/
-// and https://stackoverflow.com/a/56508132/1234545
+// Based on https://lostmoa.com/blog/DynamicHeightForTextFieldInSwiftUI and https://stackoverflow.com/a/56508132/1234545
 
 import SwiftUI
 
@@ -37,9 +36,7 @@ class PostTitleCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegat
         atEnd layoutFinishedFlag: Bool
     ) {
         DispatchQueue.main.async {
-            guard let view = self.textView else {
-                return
-            }
+            guard let view = self.textView else { return }
             let size = view.sizeThatFits(view.bounds.size)
             if self.postTitleTextView.height != size.height {
                 self.postTitleTextView.height = size.height

--- a/iOS/PostEditor/PostTitleTextView.swift
+++ b/iOS/PostEditor/PostTitleTextView.swift
@@ -3,7 +3,7 @@
 
 import SwiftUI
 
-class Coordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate {
+class PostTitleCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate {
     @Binding var text: String
     @Binding var isFirstResponder: Bool
     var didBecomeFirstResponder: Bool = false
@@ -17,7 +17,7 @@ class Coordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate {
         _isFirstResponder = isFirstResponder
     }
 
-    func textViewDidChangeSelection(_ textView: UITextView) {
+    func textViewDidChange(_ textView: UITextView) {
         DispatchQueue.main.async {
             self.postTitleTextView.text = textView.text ?? ""
         }
@@ -75,7 +75,7 @@ struct PostTitleTextView: UIViewRepresentable {
         return textView
     }
 
-    func makeCoordinator() -> Coordinator {
+    func makeCoordinator() -> PostTitleCoordinator {
         return Coordinator(self, text: $text, isFirstResponder: $isFirstResponder)
     }
 

--- a/iOS/PostEditor/PostTitleTextView.swift
+++ b/iOS/PostEditor/PostTitleTextView.swift
@@ -1,0 +1,20 @@
+//
+//  PostTitleTextView.swift
+//  WriteFreely-MultiPlatform (iOS)
+//
+//  Created by Angelo Stavrow on 2020-10-27.
+//
+
+import SwiftUI
+
+struct PostTitleTextView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct PostTitleTextView_Previews: PreviewProvider {
+    static var previews: some View {
+        PostTitleTextView()
+    }
+}

--- a/iOS/PostEditor/PostTitleTextView.swift
+++ b/iOS/PostEditor/PostTitleTextView.swift
@@ -32,6 +32,7 @@ class PostTitleCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegat
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         if text == "\n" {
             self.isFirstResponder.toggle()
+            self.didBecomeFirstResponder = false
             return false
         }
         return true

--- a/iOS/PostEditor/PostTitleTextView.swift
+++ b/iOS/PostEditor/PostTitleTextView.swift
@@ -24,7 +24,7 @@ class Coordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate {
     }
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        if (text == "\n") {
+        if text == "\n" {
             self.isFirstResponder.toggle()
             return false
         }


### PR DESCRIPTION
Closes #104 for the iOS app; must also be implemented for the Mac app, but that's a fair bit more work, so we'll punt on this for now.

This PR also adds some little quality-of-life fixes, like the Return key switching focus from the title field to the body field (but not vice versa), and a multi-line, auto-expanding title field.