### PR TITLE
Show drafts only when logged out

### DIFF
--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -7,7 +7,7 @@ struct ContentView: View {
         NavigationView {
             SidebarView()
 
-            PostListView(selectedCollection: nil, showAllPosts: true)
+            PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
 
             Text("Select a post, or create a new local draft.")
                 .foregroundColor(.secondary)

--- a/Shared/PostCollection/CollectionListView.swift
+++ b/Shared/PostCollection/CollectionListView.swift
@@ -11,10 +11,10 @@ struct CollectionListView: View {
 
     var body: some View {
         List {
-            NavigationLink(destination: PostListView(selectedCollection: nil, showAllPosts: true)) {
-                Text("All Posts")
-            }
             if model.account.isLoggedIn {
+                NavigationLink(destination: PostListView(selectedCollection: nil, showAllPosts: true)) {
+                    Text("All Posts")
+                }
                 NavigationLink(destination: PostListView(selectedCollection: nil, showAllPosts: false)) {
                     Text(model.account.server == "https://write.as" ? "Anonymous" : "Drafts")
                 }
@@ -26,6 +26,10 @@ struct CollectionListView: View {
                             Text(collection.title)
                         }
                     }
+                }
+            } else {
+                NavigationLink(destination: PostListView(selectedCollection: nil, showAllPosts: false)) {
+                    Text("Drafts")
                 }
             }
         }


### PR DESCRIPTION
Closes #101.

This PR is pretty straightforward: when logged out, the app showed "All Posts" as the only list. With changes between the beta and release versions, new local posts would get created in "Drafts", and would therefore show **<&nbsp;Drafts** in the navigation bar, which was not a list that could be navigated to from the collection-list sidebar.

With these changes, if you're logged out, you only see the one list, Drafts, where your new local posts are created.