### PR TITLE
Present error alert if token is invalid and ensure user is logged out

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -325,6 +325,12 @@ private extension WriteFreelyModel {
             DispatchQueue.main.async {
                 LocalStorageManager().saveContext()
             }
+        } catch WFError.unauthorized {
+            DispatchQueue.main.async {
+                self.loginErrorMessage = "Something went wrong, please try logging in again."
+                self.isPresentingLoginErrorAlert = true
+            }
+            self.logout()
         } catch {
             print(error)
         }
@@ -376,6 +382,12 @@ private extension WriteFreelyModel {
             } catch {
                 print(error)
             }
+        } catch WFError.unauthorized {
+            DispatchQueue.main.async {
+                self.loginErrorMessage = "Something went wrong, please try logging in again."
+                self.isPresentingLoginErrorAlert = true
+            }
+            self.logout()
         } catch {
             print("Error: Failed to fetch cached posts")
         }


### PR DESCRIPTION
Fixes #119.

This PR catches invalid tokens when fetching user content (the first actions taken by the app after logging in) and, if it finds one, puts up an alert indicating that something went wrong and ensures that the app correctly shows that the user is logged out.