### PR TITLE
Fix cursor jump to end of post body

### DIFF
--- a/iOS/PostEditor/PostBodyTextView.swift
+++ b/iOS/PostEditor/PostBodyTextView.swift
@@ -23,12 +23,17 @@ class PostBodyCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate
         self.lineSpacingMultiplier = lineSpacingMultiplier
     }
 
+    func textViewDidChange(_ textView: UITextView) {
+        DispatchQueue.main.async {
+            self.postBodyTextView.text = textView.text ?? ""
+        }
+    }
+
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
         return true
     }
 
     func textViewDidEndEditing(_ textView: UITextView) {
-        self.postBodyTextView.text = textView.text ?? ""
         self.isFirstResponder = false
         self.didBecomeFirstResponder = false
     }

--- a/iOS/PostEditor/PostBodyTextView.swift
+++ b/iOS/PostEditor/PostBodyTextView.swift
@@ -1,4 +1,4 @@
-// Based on https://stackoverflow.com/a/56508132/1234545 and https://stackoverflow.com/a/48360549/1234545
+// Based on https://stackoverflow.com/a/56508132 and https://stackoverflow.com/a/48360549
 
 import SwiftUI
 

--- a/iOS/PostEditor/PostBodyTextView.swift
+++ b/iOS/PostEditor/PostBodyTextView.swift
@@ -5,7 +5,6 @@ import SwiftUI
 class PostBodyCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate {
     @Binding var text: String
     @Binding var isFirstResponder: Bool
-    @Binding var currentTextPosition: UITextRange?
     var lineSpacingMultiplier: CGFloat
     var didBecomeFirstResponder: Bool = false
     var postBodyTextView: PostBodyTextView
@@ -16,37 +15,22 @@ class PostBodyCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate
         _ textView: PostBodyTextView,
         text: Binding<String>,
         isFirstResponder: Binding<Bool>,
-        currentTextPosition: Binding<UITextRange?>,
         lineSpacingMultiplier: CGFloat
     ) {
         self.postBodyTextView = textView
         _text = text
         _isFirstResponder = isFirstResponder
         self.lineSpacingMultiplier = lineSpacingMultiplier
-        _currentTextPosition = currentTextPosition
-    }
-
-    func textViewDidChange(_ textView: UITextView) {
-        DispatchQueue.main.async {
-            self.postBodyTextView.text = textView.text ?? ""
-        }
     }
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
-        self.currentTextPosition = textView.selectedTextRange
         return true
     }
 
-    func textViewDidBeginEditing(_ textView: UITextView) {
-        if let textPosition = currentTextPosition {
-            textView.selectedTextRange = textPosition
-        }
-    }
-
     func textViewDidEndEditing(_ textView: UITextView) {
+        self.postBodyTextView.text = textView.text ?? ""
         self.isFirstResponder = false
         self.didBecomeFirstResponder = false
-        self.currentTextPosition = textView.selectedTextRange
     }
 
     func layoutManager(
@@ -75,11 +59,10 @@ struct PostBodyTextView: UIViewRepresentable {
     @Binding var text: String
     @Binding var textStyle: UIFont
     @Binding var isFirstResponder: Bool
-    @Binding var currentTextPosition: UITextRange?
     @State var lineSpacing: CGFloat
 
     func makeUIView(context: UIViewRepresentableContext<PostBodyTextView>) -> UITextView {
-        let textView = UITextView(frame: .zero)
+        let textView = UITextView()
 
         textView.isEditable = true
         textView.isUserInteractionEnabled = true
@@ -93,6 +76,7 @@ struct PostBodyTextView: UIViewRepresentable {
         let font = textStyle
         let fontMetrics = UIFontMetrics(forTextStyle: .largeTitle)
         textView.font = fontMetrics.scaledFont(for: font)
+
         textView.backgroundColor = UIColor.clear
 
         return textView
@@ -103,7 +87,6 @@ struct PostBodyTextView: UIViewRepresentable {
             self,
             text: $text,
             isFirstResponder: $isFirstResponder,
-            currentTextPosition: $currentTextPosition,
             lineSpacingMultiplier: lineSpacing
         )
     }

--- a/iOS/PostEditor/PostTextEditingView.swift
+++ b/iOS/PostEditor/PostTextEditingView.swift
@@ -11,7 +11,6 @@ struct PostTextEditingView: View {
     @State private var titleIsFirstResponder: Bool = true
     @State private var bodyTextStyle: UIFont = UIFont(name: "Lora-Regular", size: 17)!
     @State private var bodyIsFirstResponder: Bool = false
-    @State private var bodyCursorPosition: UITextRange?
     private let lineSpacingMultiplier: CGFloat = 0.5
 
     init(
@@ -72,7 +71,6 @@ struct PostTextEditingView: View {
                     text: $post.body,
                     textStyle: $bodyTextStyle,
                     isFirstResponder: $bodyIsFirstResponder,
-                    currentTextPosition: $bodyCursorPosition,
                     lineSpacing: horizontalSizeClass == .compact ? lineSpacingMultiplier / 2 : lineSpacingMultiplier
                 )
                 .onChange(of: post.body) { _ in

--- a/iOS/PostEditor/PostTitleTextView.swift
+++ b/iOS/PostEditor/PostTitleTextView.swift
@@ -1,4 +1,4 @@
-// Based on https://lostmoa.com/blog/DynamicHeightForTextFieldInSwiftUI and https://stackoverflow.com/a/56508132/1234545
+// Based on https://lostmoa.com/blog/DynamicHeightForTextFieldInSwiftUI and https://stackoverflow.com/a/56508132
 
 import SwiftUI
 


### PR DESCRIPTION
Fixes #122.

This PR removes the logic to jump to the last-known cursor position in the body field (if any); when tapping the <kbd>Return</kbd> key from the title field, the cursor now jumps to the end of any text that exists in the body field.