### PR TITLE
Use NSViewRepresentable-wrapped NSTextViews instead of SwiftUI controls

### DIFF
--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -20,8 +20,10 @@
 		17120DB224E1E19C002B9F6C /* SettingsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17120DB124E1E19C002B9F6C /* SettingsHeaderView.swift */; };
 		171BFDFA24D4AF8300888236 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171BFDF924D4AF8300888236 /* CollectionListView.swift */; };
 		171BFDFB24D4AF8300888236 /* CollectionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171BFDF924D4AF8300888236 /* CollectionListView.swift */; };
+		171C057125657E05006AC54E /* PostTitleTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 171C057025657E05006AC54E /* PostTitleTextView.swift */; };
 		173E19D1254318F600440F0F /* RemoteChangePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173E19D0254318F600440F0F /* RemoteChangePromptView.swift */; };
 		173E19E3254329CC00440F0F /* PostTextEditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173E19E2254329CC00440F0F /* PostTextEditingView.swift */; };
+		174665D42566FE9800629997 /* PostBodyTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174665D32566FE9800629997 /* PostBodyTextView.swift */; };
 		17480CA5251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */; };
 		17480CA6251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */; };
 		174D313224EC2831006CA9EE /* WriteFreelyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174D313124EC2831006CA9EE /* WriteFreelyModel.swift */; };
@@ -121,8 +123,10 @@
 		17120DAB24E1B99F002B9F6C /* AccountLoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountLoginView.swift; sourceTree = "<group>"; };
 		17120DB124E1E19C002B9F6C /* SettingsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsHeaderView.swift; sourceTree = "<group>"; };
 		171BFDF924D4AF8300888236 /* CollectionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionListView.swift; sourceTree = "<group>"; };
+		171C057025657E05006AC54E /* PostTitleTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTitleTextView.swift; sourceTree = "<group>"; };
 		173E19D0254318F600440F0F /* RemoteChangePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteChangePromptView.swift; sourceTree = "<group>"; };
 		173E19E2254329CC00440F0F /* PostTextEditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTextEditingView.swift; sourceTree = "<group>"; };
+		174665D32566FE9800629997 /* PostBodyTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostBodyTextView.swift; sourceTree = "<group>"; };
 		17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppVersion.swift"; sourceTree = "<group>"; };
 		174D313124EC2831006CA9EE /* WriteFreelyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteFreelyModel.swift; sourceTree = "<group>"; };
 		1753F6AB24E431CC00309365 /* MacPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacPreferencesView.swift; sourceTree = "<group>"; };
@@ -309,6 +313,8 @@
 			children = (
 				17A67CAE251A5DD7002F163D /* PostEditorView.swift */,
 				17E5DF892543610700DCDC9B /* PostTextEditingView.swift */,
+				171C057025657E05006AC54E /* PostTitleTextView.swift */,
+				174665D32566FE9800629997 /* PostBodyTextView.swift */,
 			);
 			path = PostEditor;
 			sourceTree = "<group>";
@@ -734,6 +740,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				174665D42566FE9800629997 /* PostBodyTextView.swift in Sources */,
 				17DF32AD24C87D3500BCE2E3 /* ContentView.swift in Sources */,
 				1765F62B24E18EA200C9EBF0 /* SidebarView.swift in Sources */,
 				1756DBBB24FED45500207AB8 /* LocalStorageManager.swift in Sources */,
@@ -760,6 +767,7 @@
 				1756AE6F24CB255B00FD7257 /* PostListModel.swift in Sources */,
 				1756DC0224FEE18400207AB8 /* WFACollection+CoreDataClass.swift in Sources */,
 				1756DBB424FECDBB00207AB8 /* PostEditorStatusToolbarView.swift in Sources */,
+				171C057125657E05006AC54E /* PostTitleTextView.swift in Sources */,
 				17A5388F24DDEC7400DEFF9A /* AccountView.swift in Sources */,
 				170DFA35251BBC44001D82A0 /* PostEditorModel.swift in Sources */,
 				1756AE7524CB26FA00FD7257 /* PostCellView.swift in Sources */,

--- a/iOS/PostEditor/PostTitleTextView.swift
+++ b/iOS/PostEditor/PostTitleTextView.swift
@@ -1,5 +1,3 @@
-// Based on https://lostmoa.com/blog/DynamicHeightForTextFieldInSwiftUI and https://stackoverflow.com/a/56508132
-
 import SwiftUI
 
 class PostTitleCoordinator: NSObject, UITextViewDelegate, NSLayoutManagerDelegate {

--- a/macOS/PostEditor/PostBodyTextView.swift
+++ b/macOS/PostEditor/PostBodyTextView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+class PostBodyCoordinator: NSObject, NSTextViewDelegate, NSLayoutManagerDelegate {
+    @Binding var text: String
+    @Binding var isFirstResponder: Bool
+    var didBecomeFirstResponder: Bool = false
+    var postBodyTextView: PostBodyTextView
+
+    init(
+        _ textView: PostBodyTextView,
+        text: Binding<String>,
+        isFirstResponder: Binding<Bool>
+    ) {
+        self.postBodyTextView = textView
+        _text = text
+        _isFirstResponder = isFirstResponder
+    }
+
+    func textDidChange(_ notification: Notification) {
+        guard let textView = notification.object as? NSTextView else { return }
+        DispatchQueue.main.async {
+            self.postBodyTextView.text = textView.string
+        }
+    }
+
+    func textDidEndEditing(_ notification: Notification) {
+        DispatchQueue.main.async {
+            self.isFirstResponder = false
+            self.didBecomeFirstResponder = false
+        }
+    }
+}
+
+struct PostBodyTextView: NSViewRepresentable {
+    @Binding var text: String
+    @Binding var textStyle: NSFont
+    @Binding var isFirstResponder: Bool
+
+    private let defaultLineHeight: CGFloat = 33
+
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
+
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.font = textStyle
+        textView.delegate = context.coordinator
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.autoresizingMask = [.width, .height]
+        textView.backgroundColor = NSColor.clear
+
+        return textView
+    }
+
+    func makeCoordinator() -> PostBodyCoordinator {
+        return Coordinator(self, text: $text, isFirstResponder: $isFirstResponder)
+    }
+
+    func updateNSView(_ nsView: NSTextView, context: Context) {
+        if nsView.string != text {
+            nsView.string = text
+        }
+
+        nsView.font = textStyle
+
+        if isFirstResponder && !context.coordinator.didBecomeFirstResponder {
+            DispatchQueue.main.async {
+                NSApplication.shared.keyWindow?.makeFirstResponder(nsView)
+                context.coordinator.didBecomeFirstResponder = true
+            }
+        }
+    }
+}

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -1,21 +1,20 @@
 import SwiftUI
 
 struct PostEditorView: View {
-    private let bodyLineSpacing: CGFloat = 17 * 0.5
     @EnvironmentObject var model: WriteFreelyModel
 
     @ObservedObject var post: WFAPost
-    @State private var isHovering: Bool = false
     @State private var updatingTitleFromServer: Bool = false
     @State private var updatingBodyFromServer: Bool = false
 
     var body: some View {
         PostTextEditingView(
-            post: post,
+            post: _post,
             updatingTitleFromServer: $updatingTitleFromServer,
             updatingBodyFromServer: $updatingBodyFromServer
         )
         .padding()
+        .background(Color(NSColor.controlBackgroundColor))
         .toolbar {
             ToolbarItem(placement: .status) {
                 PostEditorStatusToolbarView(post: post)

--- a/macOS/PostEditor/PostTextEditingView.swift
+++ b/macOS/PostEditor/PostTextEditingView.swift
@@ -4,16 +4,39 @@ struct PostTextEditingView: View {
     @ObservedObject var post: WFAPost
     @Binding var updatingTitleFromServer: Bool
     @Binding var updatingBodyFromServer: Bool
-    @State private var isHovering: Bool = false
     @State private var appearance: PostAppearance = .serif
+    @State private var titleTextStyle: NSFont = NSFont(name: "Lora-Regular", size: 26)!
+    @State private var titleTextHeight: CGFloat = 33
+    @State private var titleIsFirstResponder: Bool = true
+    @State private var bodyTextStyle: NSFont = NSFont(name: "Lora-Regular", size: 17)!
+    @State private var bodyIsFirstResponder: Bool = false
     private let bodyLineSpacingMultiplier: CGFloat = 0.5
+
+    init(
+        post: ObservedObject<WFAPost>,
+        updatingTitleFromServer: Binding<Bool>,
+        updatingBodyFromServer: Binding<Bool>
+    ) {
+        self._post = post
+        self._updatingTitleFromServer = updatingTitleFromServer
+        self._updatingBodyFromServer = updatingBodyFromServer
+    }
 
     var body: some View {
         VStack {
-            TextField("Title (optional)", text: $post.title)
-                .textFieldStyle(PlainTextFieldStyle())
-                .padding(.horizontal, 4)
-                .font(.custom(appearance.rawValue, size: 26, relativeTo: .largeTitle))
+            ZStack(alignment: .topLeading) {
+                if post.title.count == 0 {
+                    Text("Title (optional)")
+                        .font(Font(titleTextStyle))
+                        .foregroundColor(Color(NSColor.placeholderTextColor))
+                        .padding(.horizontal, 4)
+                }
+                PostTitleTextView(
+                    text: $post.title,
+                    textStyle: $titleTextStyle,
+                    isFirstResponder: $titleIsFirstResponder
+                )
+                .frame(height: titleTextHeight)
                 .onChange(of: post.title) { _ in
                     if post.status == PostStatus.published.rawValue && !updatingTitleFromServer {
                         post.status = PostStatus.edited.rawValue
@@ -22,21 +45,16 @@ struct PostTextEditingView: View {
                         updatingTitleFromServer = false
                     }
                 }
-                .padding(4)
-                .background(Color(NSColor.controlBackgroundColor))
-                .padding(.bottom)
+            }
+            .padding(4)
             ZStack(alignment: .topLeading) {
                 if post.body.count == 0 {
                     Text("Write…")
+                        .font(Font(bodyTextStyle))
                         .foregroundColor(Color(NSColor.placeholderTextColor))
                         .padding(.horizontal, 4)
-                        .padding(.vertical, 2)
-                        .font(.custom(appearance.rawValue, size: 17, relativeTo: .body))
                 }
-                TextEditor(text: $post.body)
-                    .font(.custom(appearance.rawValue, size: 17, relativeTo: .body))
-                    .lineSpacing(17 * bodyLineSpacingMultiplier)
-                    .opacity(post.body.count == 0 && !isHovering ? 0.0 : 1.0)
+                PostBodyTextView(text: $post.body, textStyle: $bodyTextStyle, isFirstResponder: $bodyIsFirstResponder)
                     .onChange(of: post.body) { _ in
                         if post.status == PostStatus.published.rawValue && !updatingBodyFromServer {
                             post.status = PostStatus.edited.rawValue
@@ -45,22 +63,42 @@ struct PostTextEditingView: View {
                             updatingBodyFromServer = false
                         }
                     }
-                    .onHover(perform: { hovering in
-                        self.isHovering = hovering
-                    })
             }
             .padding(4)
-            .background(Color(NSColor.controlBackgroundColor))
         }
-        .onAppear(perform: {
-            switch post.appearance {
-            case "sans":
-                self.appearance = .sans
-            case "wrap", "mono", "code":
-                self.appearance = .mono
-            default:
-                self.appearance = .serif
+        .onChange(of: titleIsFirstResponder, perform: { value in
+            if !value {
+                self.bodyIsFirstResponder = true
             }
         })
+        .onChange(of: bodyIsFirstResponder, perform: { value in
+            if !value {
+                self.titleIsFirstResponder = true
+            }
+        })
+        .onAppear(perform: {
+            let fontName = getFontNameFromPost(post)
+            DispatchQueue.main.async {
+                self.titleTextStyle = NSFont(name: fontName, size: 26)!
+                self.bodyTextStyle = NSFont(name: fontName, size: 17)!
+            }
+        })
+        .onDisappear(perform: {
+            DispatchQueue.main.async {
+                self.titleIsFirstResponder = true
+            }
+        })
+    }
+
+    private func getFontNameFromPost(_ post: WFAPost) -> String {
+        switch post.appearance {
+        case "sans":
+            self.appearance = .sans
+        case "wrap", "mono", "code":
+            self.appearance = .mono
+        default:
+            self.appearance = .serif
+        }
+        return appearance.rawValue
     }
 }

--- a/macOS/PostEditor/PostTitleTextView.swift
+++ b/macOS/PostEditor/PostTitleTextView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+class PostTitleCoordinator: NSObject, NSTextViewDelegate {
+    @Binding var text: String
+    @Binding var isFirstResponder: Bool
+    var didBecomeFirstResponder: Bool = false
+    var postTitleTextView: PostTitleTextView
+
+    init(
+        _ textView: PostTitleTextView,
+        text: Binding<String>,
+        isFirstResponder: Binding<Bool>
+    ) {
+        self.postTitleTextView = textView
+        _text = text
+        _isFirstResponder = isFirstResponder
+    }
+
+    func textDidChange(_ notification: Notification) {
+        guard let textView = notification.object as? NSTextView else { return }
+        DispatchQueue.main.async {
+            self.postTitleTextView.text = textView.string
+        }
+    }
+
+    func textDidEndEditing(_ notification: Notification) {
+        DispatchQueue.main.async {
+            self.isFirstResponder = false
+            self.didBecomeFirstResponder = false
+        }
+    }
+
+    func textView(
+        _ textView: NSTextView,
+        shouldChangeTextIn affectedCharRange: NSRange,
+        replacementString: String?
+    ) -> Bool {
+        if replacementString == "\n" {
+            self.isFirstResponder.toggle()
+            self.didBecomeFirstResponder = false
+            return false
+        }
+        return true
+    }
+}
+
+struct PostTitleTextView: NSViewRepresentable {
+    @Binding var text: String
+    @Binding var textStyle: NSFont
+    @Binding var isFirstResponder: Bool
+
+    func makeNSView(context: Context) -> NSTextView {
+        let textView = NSTextView()
+
+        textView.isEditable = true
+        textView.isSelectable = true
+        textView.font = textStyle
+        textView.delegate = context.coordinator
+        textView.backgroundColor = NSColor.clear
+
+        return textView
+    }
+
+    func makeCoordinator() -> PostTitleCoordinator {
+        return Coordinator(self, text: $text, isFirstResponder: $isFirstResponder)
+    }
+
+    func updateNSView(_ nsView: NSTextView, context: Context) {
+        if nsView.string != text {
+            nsView.string = text
+        }
+
+        nsView.font = textStyle
+
+        if isFirstResponder && !context.coordinator.didBecomeFirstResponder {
+            DispatchQueue.main.async {
+                NSApplication.shared.keyWindow?.makeFirstResponder(nsView)
+                context.coordinator.didBecomeFirstResponder = true
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #115.

This is essentially the same work as was done in #104 for the iOS app — rather than use standard SwiftUI controls like TextField and TextEditor, we're dropping into AppKit to use NSViewRepresentable-wrapped NSTextViews for both the title and body fields, setting the title field as the first responder on load, and watching for the Return key in the title field to skip to the body field.