### PR TITLE
Overhaul toolbar on Mac app

### DIFF
--- a/Shared/Account/AccountModel.swift
+++ b/Shared/Account/AccountModel.swift
@@ -1,4 +1,4 @@
-import Foundation
+import SwiftUI
 import WriteFreely
 
 enum AccountError: Error {
@@ -30,8 +30,8 @@ extension AccountError: LocalizedError {
 }
 
 struct AccountModel {
+    @AppStorage("isLoggedIn") var isLoggedIn: Bool = false
     private let defaults = UserDefaults.standard
-    let isLoggedInFlag = "isLoggedInFlag"
     let usernameStringKey = "usernameStringKey"
     let serverStringKey = "serverStringKey"
 
@@ -39,13 +39,11 @@ struct AccountModel {
     var username: String = ""
 
     private(set) var user: WFUser?
-    private(set) var isLoggedIn: Bool = false
 
     mutating func login(_ user: WFUser) {
         self.user = user
         self.username = user.username ?? ""
         self.isLoggedIn = true
-        defaults.set(true, forKey: isLoggedInFlag)
         defaults.set(user.username, forKey: usernameStringKey)
         defaults.set(server, forKey: serverStringKey)
     }
@@ -53,13 +51,11 @@ struct AccountModel {
     mutating func logout() {
         self.user = nil
         self.isLoggedIn = false
-        defaults.set(false, forKey: isLoggedInFlag)
         defaults.removeObject(forKey: usernameStringKey)
         defaults.removeObject(forKey: serverStringKey)
     }
 
     mutating func restoreState() {
-        isLoggedIn = defaults.bool(forKey: isLoggedInFlag)
         server = defaults.string(forKey: serverStringKey) ?? ""
         username = defaults.string(forKey: usernameStringKey) ?? ""
     }

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -70,8 +70,13 @@ struct ContentView: View {
                     }
                     ToolbarItemGroup(placement: .primaryAction) {
                         if let selectedPost = model.selectedPost {
-                            Button(action: {}, label: { Image(systemName: "paperplane") })
-                                .disabled(selectedPost.body.isEmpty)
+                            Button(action: {
+                                DispatchQueue.main.async {
+                                    LocalStorageManager().saveContext()
+                                    model.publish(post: selectedPost)
+                                }
+                            }, label: { Image(systemName: "paperplane") })
+                            .disabled(selectedPost.body.isEmpty || selectedPost.status == PostStatus.published.rawValue)
                             Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
                                 .disabled(selectedPost.status == PostStatus.local.rawValue)
                         }

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -60,8 +60,9 @@ struct ContentView: View {
                                 model.fetchUserPosts()
                             }
                         }, label: { Image(systemName: "arrow.clockwise") })
-                            .padding(.leading, sidebarIsHidden ? 8 : 0)
-                            .animation(.linear)
+                        .disabled(!model.account.isLoggedIn)
+                        .padding(.leading, sidebarIsHidden ? 8 : 0)
+                        .animation(.linear)
                     }
                     ToolbarItem(placement: .status) {
                         if let selectedPost = model.selectedPost {

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
                     }
                     ToolbarItem(placement: .status) {
                         if let selectedPost = model.selectedPost {
-                            PostStatusBadgeView(post: selectedPost)
+                            PostEditorStatusToolbarView(post: selectedPost)
                         }
                     }
                     ToolbarItemGroup(placement: .primaryAction) {

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -42,7 +42,9 @@ struct ContentView: View {
                             managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
                         }
                         withAnimation {
-                            self.model.selectedPost = managedPost
+                            DispatchQueue.main.async {
+                                self.model.selectedPost = managedPost
+                            }
                         }
                     }, label: { Image(systemName: "square.and.pencil") })
                 }

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var model: WriteFreelyModel
-    @Binding var sidebarIsHidden: Bool
 
     var body: some View {
         NavigationView {
@@ -14,7 +13,6 @@ struct ContentView: View {
                             NSApp.keyWindow?.contentViewController?.tryToPerform(
                                 #selector(NSSplitViewController.toggleSidebar(_:)), with: nil
                             )
-                            withAnimation { self.sidebarIsHidden.toggle() }
                         },
                         label: { Image(systemName: "sidebar.left") }
                     )
@@ -55,31 +53,20 @@ struct ContentView: View {
             #if os(macOS)
             PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
                 .toolbar {
-                    ToolbarItem(placement: .navigation) {
-                        Button(action: {
-                            DispatchQueue.main.async {
-                                model.fetchUserCollections()
-                                model.fetchUserPosts()
-                            }
-                        }, label: { Image(systemName: "arrow.clockwise") })
-                        .disabled(!model.account.isLoggedIn)
-                        .padding(.leading, sidebarIsHidden ? 8 : 0)
-                        .animation(.linear)
-                        .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
-                            Alert(
-                                title: Text("Connection Error"),
-                                message: Text("""
-                                    There is no internet connection at the moment. Please reconnect or try again later.
-                                    """),
-                                dismissButton: .default(Text("OK"), action: {
-                                    model.isPresentingNetworkErrorAlert = false
-                                })
-                            )
-                        })
-                    }
                     ToolbarItemGroup(placement: .primaryAction) {
                         if let selectedPost = model.selectedPost {
                             ActivePostToolbarView(activePost: selectedPost)
+                                .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
+                                    Alert(
+                                        title: Text("Connection Error"),
+                                        message: Text("""
+                                            There is no internet connection at the moment. Please reconnect or try again later.
+                                            """),
+                                        dismissButton: .default(Text("OK"), action: {
+                                            model.isPresentingNetworkErrorAlert = false
+                                        })
+                                    )
+                                })
                         }
                     }
                 }
@@ -122,7 +109,7 @@ struct ContentView_Previews: PreviewProvider {
         let context = LocalStorageManager.persistentContainer.viewContext
         let model = WriteFreelyModel()
 
-        return ContentView(sidebarIsHidden: .constant(false))
+        return ContentView()
             .environment(\.managedObjectContext, context)
             .environmentObject(model)
     }

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -2,24 +2,54 @@ import SwiftUI
 
 struct ContentView: View {
     @EnvironmentObject var model: WriteFreelyModel
+    @Binding var sidebarIsHidden: Bool
 
     var body: some View {
         NavigationView {
             #if os(macOS)
             SidebarView()
                 .toolbar {
-                    Button(action: {
-                        NSApp.keyWindow?.contentViewController?.tryToPerform(
-                            #selector(NSSplitViewController.toggleSidebar(_:)),
-                            with: nil
-                        )
-                    }, label: { Image(systemName: "sidebar.left") })
+                    Button(
+                        action: {
+                            NSApp.keyWindow?.contentViewController?.tryToPerform(
+                                #selector(NSSplitViewController.toggleSidebar(_:)), with: nil
+                            )
+                            withAnimation { self.sidebarIsHidden.toggle() }
+                        },
+                        label: { Image(systemName: "sidebar.left") }
+                    )
+                    Spacer()
+                    Button(action: {}, label: { Image(systemName: "square.and.pencil") })
                 }
             #else
             SidebarView()
             #endif
 
+            #if os(macOS)
             PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
+                .toolbar {
+                    ToolbarItem(placement: .navigation) {
+                        Button(action: {}, label: { Image(systemName: "arrow.clockwise") })
+                            .padding(.leading, sidebarIsHidden ? 8 : 0)
+                            .animation(.linear)
+                    }
+                    ToolbarItem(placement: .status) {
+                        if let selectedPost = model.selectedPost {
+                            PostStatusBadgeView(post: selectedPost)
+                        }
+                    }
+                    ToolbarItemGroup(placement: .primaryAction) {
+                        if let selectedPost = model.selectedPost {
+                            Button(action: {}, label: { Image(systemName: "paperplane") })
+                                .disabled(selectedPost.body.isEmpty)
+                            Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
+                                .disabled(selectedPost.status == PostStatus.local.rawValue)
+                        }
+                    }
+                }
+            #else
+            PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
+            #endif
 
             Text("Select a post, or create a new local draft.")
                 .foregroundColor(.secondary)
@@ -72,7 +102,7 @@ struct ContentView_Previews: PreviewProvider {
         let context = LocalStorageManager.persistentContainer.viewContext
         let model = WriteFreelyModel()
 
-        return ContentView()
+        return ContentView(sidebarIsHidden: .constant(false))
             .environment(\.managedObjectContext, context)
             .environmentObject(model)
     }

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -5,7 +5,19 @@ struct ContentView: View {
 
     var body: some View {
         NavigationView {
+            #if os(macOS)
             SidebarView()
+                .toolbar {
+                    Button(action: {
+                        NSApp.keyWindow?.contentViewController?.tryToPerform(
+                            #selector(NSSplitViewController.toggleSidebar(_:)),
+                            with: nil
+                        )
+                    }, label: { Image(systemName: "sidebar.left") })
+                }
+            #else
+            SidebarView()
+            #endif
 
             PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
 

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -54,7 +54,12 @@ struct ContentView: View {
             PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
                 .toolbar {
                     ToolbarItem(placement: .navigation) {
-                        Button(action: {}, label: { Image(systemName: "arrow.clockwise") })
+                        Button(action: {
+                            DispatchQueue.main.async {
+                                model.fetchUserCollections()
+                                model.fetchUserPosts()
+                            }
+                        }, label: { Image(systemName: "arrow.clockwise") })
                             .padding(.leading, sidebarIsHidden ? 8 : 0)
                             .animation(.linear)
                     }

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -118,7 +118,9 @@ struct ContentView: View {
             .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
                 Alert(
                     title: Text("Connection Error"),
-                    message: Text("There is no internet connection at the moment. Please reconnect or try again later."),
+                    message: Text("""
+                        There is no internet connection at the moment. Please reconnect or try again later.
+                        """),
                     dismissButton: .default(Text("OK"), action: {
                         model.isPresentingNetworkErrorAlert = false
                     })

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -77,22 +77,9 @@ struct ContentView: View {
                             )
                         })
                     }
-                    ToolbarItem(placement: .status) {
-                        if let selectedPost = model.selectedPost {
-                            PostEditorStatusToolbarView(post: selectedPost)
-                        }
-                    }
                     ToolbarItemGroup(placement: .primaryAction) {
                         if let selectedPost = model.selectedPost {
-                            Button(action: {
-                                DispatchQueue.main.async {
-                                    LocalStorageManager().saveContext()
-                                    model.publish(post: selectedPost)
-                                }
-                            }, label: { Image(systemName: "paperplane") })
-                            .disabled(selectedPost.body.isEmpty || selectedPost.status == PostStatus.published.rawValue)
-                            Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
-                                .disabled(selectedPost.status == PostStatus.local.rawValue)
+                            ActivePostToolbarView(activePost: selectedPost)
                         }
                     }
                 }

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -19,7 +19,32 @@ struct ContentView: View {
                         label: { Image(systemName: "sidebar.left") }
                     )
                     Spacer()
-                    Button(action: {}, label: { Image(systemName: "square.and.pencil") })
+                    Button(action: {
+                        withAnimation {
+                            self.model.selectedPost = nil
+                        }
+                        let managedPost = WFAPost(context: LocalStorageManager.persistentContainer.viewContext)
+                        managedPost.createdDate = Date()
+                        managedPost.title = ""
+                        managedPost.body = ""
+                        managedPost.status = PostStatus.local.rawValue
+                        managedPost.collectionAlias = nil
+                        switch model.preferences.font {
+                        case 1:
+                            managedPost.appearance = "sans"
+                        case 2:
+                            managedPost.appearance = "wrap"
+                        default:
+                            managedPost.appearance = "serif"
+                        }
+                        if let languageCode = Locale.current.languageCode {
+                            managedPost.language = languageCode
+                            managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
+                        }
+                        withAnimation {
+                            self.model.selectedPost = managedPost
+                        }
+                    }, label: { Image(systemName: "square.and.pencil") })
                 }
             #else
             SidebarView()

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -65,6 +65,17 @@ struct ContentView: View {
                         .disabled(!model.account.isLoggedIn)
                         .padding(.leading, sidebarIsHidden ? 8 : 0)
                         .animation(.linear)
+                        .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
+                            Alert(
+                                title: Text("Connection Error"),
+                                message: Text("""
+                                    There is no internet connection at the moment. Please reconnect or try again later.
+                                    """),
+                                dismissButton: .default(Text("OK"), action: {
+                                    model.isPresentingNetworkErrorAlert = false
+                                })
+                            )
+                        })
                     }
                     ToolbarItem(placement: .status) {
                         if let selectedPost = model.selectedPost {
@@ -93,33 +104,6 @@ struct ContentView: View {
                 .foregroundColor(.secondary)
         }
         .environmentObject(model)
-        .alert(isPresented: $model.isPresentingDeleteAlert) {
-            Alert(
-                title: Text("Delete Post?"),
-                message: Text("This action cannot be undone."),
-                primaryButton: .destructive(Text("Delete"), action: {
-                    if let postToDelete = model.postToDelete {
-                        model.selectedPost = nil
-                        DispatchQueue.main.async {
-                            model.posts.remove(postToDelete)
-                        }
-                        model.postToDelete = nil
-                    }
-                }),
-                secondaryButton: .cancel() {
-                    model.postToDelete = nil
-                }
-            )
-        }
-        .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
-            Alert(
-                title: Text("Connection Error"),
-                message: Text("There is no internet connection at the moment. Please reconnect or try again later"),
-                dismissButton: .default(Text("OK"), action: {
-                    model.isPresentingNetworkErrorAlert = false
-                })
-            )
-        })
 
         #if os(iOS)
         EmptyView()
@@ -131,6 +115,15 @@ struct ContentView: View {
                         .environmentObject(model)
                 }
             )
+            .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
+                Alert(
+                    title: Text("Connection Error"),
+                    message: Text("There is no internet connection at the moment. Please reconnect or try again later."),
+                    dismissButton: .default(Text("OK"), action: {
+                        model.isPresentingNetworkErrorAlert = false
+                    })
+                )
+            })
         #endif
     }
 }

--- a/Shared/PostEditor/PostEditorStatusToolbarView.swift
+++ b/Shared/PostEditor/PostEditorStatusToolbarView.swift
@@ -11,16 +11,21 @@ struct PostEditorStatusToolbarView: View {
             PostStatusBadgeView(post: post)
             #else
             HStack {
+                HStack {
+                    Text("⚠️ Newer copy on server. Replace local copy?")
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                    Button(action: {
+                        model.updateFromServer(post: post)
+                    }, label: {
+                        Image(systemName: "square.and.arrow.down")
+                    })
+                }
+                .padding(.horizontal)
+                .background(Color.primary.opacity(0.1))
+                .clipShape(Capsule())
+                .padding(.trailing)
                 PostStatusBadgeView(post: post)
-                    .padding(.trailing)
-                Text("⚠️ Newer copy on server. Replace local copy?")
-                    .font(.callout)
-                    .foregroundColor(.secondary)
-                Button(action: {
-                    model.updateFromServer(post: post)
-                }, label: {
-                    Image(systemName: "square.and.arrow.down")
-                })
             }
             #endif
         } else if post.wasDeletedFromServer && post.status != PostStatus.local.rawValue {
@@ -28,19 +33,24 @@ struct PostEditorStatusToolbarView: View {
             PostStatusBadgeView(post: post)
             #else
             HStack {
+                HStack {
+                    Text("⚠️ Post deleted from server. Delete local copy?")
+                        .font(.callout)
+                        .foregroundColor(.secondary)
+                    Button(action: {
+                        model.selectedPost = nil
+                        DispatchQueue.main.async {
+                            model.posts.remove(post)
+                        }
+                    }, label: {
+                        Image(systemName: "trash")
+                    })
+                }
+                .padding(.horizontal)
+                .background(Color.primary.opacity(0.1))
+                .clipShape(Capsule())
+                .padding(.trailing)
                 PostStatusBadgeView(post: post)
-                    .padding(.trailing)
-                Text("⚠️ Post deleted from server. Delete local copy?")
-                    .font(.callout)
-                    .foregroundColor(.secondary)
-                Button(action: {
-                    model.selectedPost = nil
-                    DispatchQueue.main.async {
-                        model.posts.remove(post)
-                    }
-                }, label: {
-                    Image(systemName: "trash")
-                })
             }
             #endif
         } else {

--- a/Shared/PostList/PostListFilteredView.swift
+++ b/Shared/PostList/PostListFilteredView.swift
@@ -94,6 +94,7 @@ struct PostListFilteredView: View {
                     if let postToDelete = model.postToDelete {
                         model.selectedPost = nil
                         DispatchQueue.main.async {
+                            model.editor.clearLastDraft()
                             model.posts.remove(postToDelete)
                         }
                         model.postToDelete = nil
@@ -122,7 +123,10 @@ struct PostListFilteredView: View {
 
     func delete(_ post: WFAPost) {
         DispatchQueue.main.async {
-            model.selectedPost = nil
+            if post == model.selectedPost {
+                model.selectedPost = nil
+                model.editor.clearLastDraft()
+            }
             model.posts.remove(post)
         }
     }

--- a/Shared/PostList/PostListFilteredView.swift
+++ b/Shared/PostList/PostListFilteredView.swift
@@ -103,7 +103,9 @@ struct PostListFilteredView: View {
     }
 
     func delete(_ post: WFAPost) {
-        model.posts.remove(post)
+        DispatchQueue.main.async {
+            model.posts.remove(post)
+        }
     }
 }
 

--- a/Shared/PostList/PostListFilteredView.swift
+++ b/Shared/PostList/PostListFilteredView.swift
@@ -86,6 +86,24 @@ struct PostListFilteredView: View {
                 }
             })
         }
+        .alert(isPresented: $model.isPresentingDeleteAlert) {
+            Alert(
+                title: Text("Delete Post?"),
+                message: Text("This action cannot be undone."),
+                primaryButton: .destructive(Text("Delete"), action: {
+                    if let postToDelete = model.postToDelete {
+                        model.selectedPost = nil
+                        DispatchQueue.main.async {
+                            model.posts.remove(postToDelete)
+                        }
+                        model.postToDelete = nil
+                    }
+                }),
+                secondaryButton: .cancel() {
+                    model.postToDelete = nil
+                }
+            )
+        }
         .onAppear(perform: {
             self.postCount = fetchRequest.wrappedValue.count
         })
@@ -104,6 +122,7 @@ struct PostListFilteredView: View {
 
     func delete(_ post: WFAPost) {
         DispatchQueue.main.async {
+            model.selectedPost = nil
             model.posts.remove(post)
         }
     }

--- a/Shared/PostList/PostListFilteredView.swift
+++ b/Shared/PostList/PostListFilteredView.swift
@@ -90,7 +90,10 @@ struct PostListFilteredView: View {
             Alert(
                 title: Text("Delete Post?"),
                 message: Text("This action cannot be undone."),
-                primaryButton: .destructive(Text("Delete"), action: {
+                primaryButton: .cancel() {
+                    model.postToDelete = nil
+                },
+                secondaryButton: .destructive(Text("Delete"), action: {
                     if let postToDelete = model.postToDelete {
                         model.selectedPost = nil
                         DispatchQueue.main.async {
@@ -99,10 +102,7 @@ struct PostListFilteredView: View {
                         }
                         model.postToDelete = nil
                     }
-                }),
-                secondaryButton: .cancel() {
-                    model.postToDelete = nil
-                }
+                })
             )
         }
         .onAppear(perform: {

--- a/Shared/PostList/PostListModel.swift
+++ b/Shared/PostList/PostListModel.swift
@@ -3,8 +3,10 @@ import CoreData
 
 class PostListModel: ObservableObject {
     func remove(_ post: WFAPost) {
-        LocalStorageManager.persistentContainer.viewContext.delete(post)
-        LocalStorageManager().saveContext()
+        withAnimation {
+            LocalStorageManager.persistentContainer.viewContext.delete(post)
+            LocalStorageManager().saveContext()
+        }
     }
 
     func purgePublishedPosts() {

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -86,12 +86,6 @@ struct PostListView: View {
                 )
             )
             .navigationSubtitle(postCount == 1 ? "\(postCount) post" : "\(postCount) posts")
-            .onChange(of: selectedCollection, perform: { _ in
-                DispatchQueue.main.async {
-                    self.model.selectedPost = nil
-                    self.model.editor.clearLastDraft()
-                }
-            })
         #endif
     }
 }

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -86,6 +86,12 @@ struct PostListView: View {
                 )
             )
             .navigationSubtitle(postCount == 1 ? "\(postCount) post" : "\(postCount) posts")
+            .onChange(of: selectedCollection, perform: { _ in
+                DispatchQueue.main.async {
+                    self.model.selectedPost = nil
+                    self.model.editor.clearLastDraft()
+                }
+            })
         #endif
     }
 }

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -61,55 +61,7 @@ struct PostListView: View {
                 )
             )
             .navigationSubtitle(postCount == 1 ? "\(postCount) post" : "\(postCount) posts")
-            .toolbar {
-                Button(action: {
-                    createNewLocalDraft()
-                }, label: {
-                    Image(systemName: "square.and.pencil")
-                })
-                Button(action: {
-                    reloadFromServer()
-                }, label: {
-                    Image(systemName: "arrow.clockwise")
-                })
-                .disabled(!model.account.isLoggedIn)
-            }
         #endif
-    }
-
-    private func reloadFromServer() {
-        DispatchQueue.main.async {
-            model.fetchUserCollections()
-            model.fetchUserPosts()
-        }
-    }
-
-    private func createNewLocalDraft() {
-        let managedPost = WFAPost(context: self.managedObjectContext)
-        managedPost.createdDate = Date()
-        managedPost.title = ""
-        managedPost.body = ""
-        managedPost.status = PostStatus.local.rawValue
-        managedPost.collectionAlias = nil
-        switch model.preferences.font {
-        case 1:
-            managedPost.appearance = "sans"
-        case 2:
-            managedPost.appearance = "wrap"
-        default:
-            managedPost.appearance = "serif"
-        }
-        if let languageCode = Locale.current.languageCode {
-            managedPost.language = languageCode
-            managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
-        }
-        DispatchQueue.main.async {
-            self.selectedCollection = nil
-            self.showAllPosts = false
-            withAnimation {
-                self.model.selectedPost = managedPost
-            }
-        }
     }
 }
 

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -21,7 +21,29 @@ struct PostListView: View {
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button(action: {
-                        createNewLocalDraft()
+                        let managedPost = WFAPost(context: self.managedObjectContext)
+                        managedPost.createdDate = Date()
+                        managedPost.title = ""
+                        managedPost.body = ""
+                        managedPost.status = PostStatus.local.rawValue
+                        managedPost.collectionAlias = nil
+                        switch model.preferences.font {
+                        case 1:
+                            managedPost.appearance = "sans"
+                        case 2:
+                            managedPost.appearance = "wrap"
+                        default:
+                            managedPost.appearance = "serif"
+                        }
+                        if let languageCode = Locale.current.languageCode {
+                            managedPost.language = languageCode
+                            managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
+                        }
+                        withAnimation {
+                            self.selectedCollection = nil
+                            self.showAllPosts = false
+                            self.model.selectedPost = managedPost
+                        }
                     }, label: {
                         Image(systemName: "square.and.pencil")
                     })
@@ -41,7 +63,10 @@ struct PostListView: View {
                             ProgressView()
                         } else {
                             Button(action: {
-                                reloadFromServer()
+                                DispatchQueue.main.async {
+                                    model.fetchUserCollections()
+                                    model.fetchUserPosts()
+                                }
                             }, label: {
                                 Image(systemName: "arrow.clockwise")
                             })

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -3,7 +3,6 @@ import SwiftUI
 @main
 struct WriteFreely_MultiPlatformApp: App {
     @StateObject private var model = WriteFreelyModel()
-    @State private var sidebarIsHidden: Bool = false
 
     #if os(macOS)
     @State private var selectedTab = 0
@@ -11,7 +10,7 @@ struct WriteFreely_MultiPlatformApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView(sidebarIsHidden: $sidebarIsHidden)
+            ContentView()
                 .onAppear(perform: {
                     if let lastDraft = model.editor.fetchLastDraftFromUserDefaults() {
                         self.model.selectedPost = lastDraft

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -25,7 +25,7 @@ struct WriteFreely_MultiPlatformApp: App {
         }
         .commands {
             CommandGroup(replacing: .newItem, addition: {
-                Button("New Local Draft") {
+                Button("New Post") {
                     createNewLocalPost()
                 }
                 .keyboardShortcut("n", modifiers: [.command])

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -3,10 +3,10 @@ import SwiftUI
 @main
 struct WriteFreely_MultiPlatformApp: App {
     @StateObject private var model = WriteFreelyModel()
+    @State private var sidebarIsHidden: Bool = false
 
     #if os(macOS)
     @State private var selectedTab = 0
-    @State private var sidebarIsHidden: Bool = false
     #endif
 
     var body: some Scene {
@@ -24,6 +24,13 @@ struct WriteFreely_MultiPlatformApp: App {
 //                .preferredColorScheme(preferences.selectedColorScheme)    // See PreferencesModel for info.
         }
         .commands {
+            CommandGroup(replacing: .newItem, addition: {
+                Button("New Local Draft") {
+                    createNewLocalPost()
+                }
+                .keyboardShortcut("n", modifiers: [.command])
+            })
+            #if os(macOS)
             CommandGroup(after: .sidebar) {
                 Button("Toggle Sidebar") {
                     NSApp.keyWindow?.contentViewController?.tryToPerform(
@@ -33,6 +40,7 @@ struct WriteFreely_MultiPlatformApp: App {
                 }
                 .keyboardShortcut("s", modifiers: [.command, .option])
             }
+            #endif
         }
 
         #if os(macOS)
@@ -60,6 +68,9 @@ struct WriteFreely_MultiPlatformApp: App {
     }
 
     private func createNewLocalPost() {
+        withAnimation {
+            self.model.selectedPost = nil
+        }
         let managedPost = WFAPost(context: LocalStorageManager.persistentContainer.viewContext)
         managedPost.createdDate = Date()
         managedPost.title = ""
@@ -78,6 +89,8 @@ struct WriteFreely_MultiPlatformApp: App {
             managedPost.language = languageCode
             managedPost.rtl = Locale.characterDirection(forLanguage: languageCode) == .rightToLeft
         }
-        self.model.selectedPost = managedPost
+        withAnimation {
+            self.model.selectedPost = managedPost
+        }
     }
 }

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -22,6 +22,9 @@ struct WriteFreely_MultiPlatformApp: App {
                 .environment(\.managedObjectContext, LocalStorageManager.persistentContainer.viewContext)
 //                .preferredColorScheme(preferences.selectedColorScheme)    // See PreferencesModel for info.
         }
+        .commands {
+            SidebarCommands()
+        }
 
         #if os(macOS)
         Settings {

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -37,6 +37,7 @@ struct WriteFreely_MultiPlatformApp: App {
                         model.fetchUserPosts()
                     }
                 }
+                .disabled(!model.account.isLoggedIn)
                 .keyboardShortcut("r", modifiers: [.command])
             }
             #if os(macOS)

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -30,6 +30,15 @@ struct WriteFreely_MultiPlatformApp: App {
                 }
                 .keyboardShortcut("n", modifiers: [.command])
             })
+            CommandGroup(after: .newItem) {
+                Button("Reload From Server") {
+                    DispatchQueue.main.async {
+                        model.fetchUserCollections()
+                        model.fetchUserPosts()
+                    }
+                }
+                .keyboardShortcut("r", modifiers: [.command])
+            }
             #if os(macOS)
             CommandGroup(after: .sidebar) {
                 Button("Toggle Sidebar") {

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -6,11 +6,12 @@ struct WriteFreely_MultiPlatformApp: App {
 
     #if os(macOS)
     @State private var selectedTab = 0
+    @State private var sidebarIsHidden: Bool = false
     #endif
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(sidebarIsHidden: $sidebarIsHidden)
                 .onAppear(perform: {
                     if let lastDraft = model.editor.fetchLastDraftFromUserDefaults() {
                         self.model.selectedPost = lastDraft
@@ -23,7 +24,15 @@ struct WriteFreely_MultiPlatformApp: App {
 //                .preferredColorScheme(preferences.selectedColorScheme)    // See PreferencesModel for info.
         }
         .commands {
-            SidebarCommands()
+            CommandGroup(after: .sidebar) {
+                Button("Toggle Sidebar") {
+                    NSApp.keyWindow?.contentViewController?.tryToPerform(
+                        #selector(NSSplitViewController.toggleSidebar(_:)), with: nil
+                    )
+                    withAnimation { self.sidebarIsHidden.toggle() }
+                }
+                .keyboardShortcut("s", modifiers: [.command, .option])
+            }
         }
 
         #if os(macOS)

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -30,7 +30,7 @@ struct WriteFreely_MultiPlatformApp: App {
                 .keyboardShortcut("n", modifiers: [.command])
             })
             CommandGroup(after: .newItem) {
-                Button("Reload From Server") {
+                Button("Refresh Posts") {
                     DispatchQueue.main.async {
                         model.fetchUserCollections()
                         model.fetchUserPosts()

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -40,15 +40,7 @@ struct WriteFreely_MultiPlatformApp: App {
                 .keyboardShortcut("r", modifiers: [.command])
             }
             #if os(macOS)
-            CommandGroup(after: .sidebar) {
-                Button("Toggle Sidebar") {
-                    NSApp.keyWindow?.contentViewController?.tryToPerform(
-                        #selector(NSSplitViewController.toggleSidebar(_:)), with: nil
-                    )
-                    withAnimation { self.sidebarIsHidden.toggle() }
-                }
-                .keyboardShortcut("s", modifiers: [.command, .option])
-            }
+            SidebarCommands()
             #endif
         }
 

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		17B996D92502D23E0017B536 /* WFAPost+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B996D62502D23E0017B536 /* WFAPost+CoreDataClass.swift */; };
 		17B996DA2502D23E0017B536 /* WFAPost+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B996D72502D23E0017B536 /* WFAPost+CoreDataProperties.swift */; };
 		17B996DB2502D23E0017B536 /* WFAPost+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B996D72502D23E0017B536 /* WFAPost+CoreDataProperties.swift */; };
+		17BC618A25715318003363CA /* ActivePostToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17BC617825715068003363CA /* ActivePostToolbarView.swift */; };
 		17C42E622507D8E600072984 /* PostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C42E612507D8E600072984 /* PostStatus.swift */; };
 		17C42E632507D8E600072984 /* PostStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C42E612507D8E600072984 /* PostStatus.swift */; };
 		17C42E652509237800072984 /* PostListFilteredView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17C42E642509237800072984 /* PostListFilteredView.swift */; };
@@ -151,6 +152,7 @@
 		17B5103A2515448D00E9631F /* Credits.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Credits.rtf; sourceTree = "<group>"; };
 		17B996D62502D23E0017B536 /* WFAPost+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WFAPost+CoreDataClass.swift"; sourceTree = SOURCE_ROOT; };
 		17B996D72502D23E0017B536 /* WFAPost+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WFAPost+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
+		17BC617825715068003363CA /* ActivePostToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivePostToolbarView.swift; sourceTree = "<group>"; };
 		17C42E612507D8E600072984 /* PostStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStatus.swift; sourceTree = "<group>"; };
 		17C42E642509237800072984 /* PostListFilteredView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListFilteredView.swift; sourceTree = "<group>"; };
 		17C42E6F250AA12200072984 /* NSManagedObjectContext+ExecuteAndMergeChanges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObjectContext+ExecuteAndMergeChanges.swift"; sourceTree = "<group>"; };
@@ -316,6 +318,14 @@
 			path = PostEditor;
 			sourceTree = "<group>";
 		};
+		17BC617725715042003363CA /* Navigation */ = {
+			isa = PBXGroup;
+			children = (
+				17BC617825715068003363CA /* ActivePostToolbarView.swift */,
+			);
+			path = Navigation;
+			sourceTree = "<group>";
+		};
 		17D4F3722514EE4400517CE6 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -393,6 +403,7 @@
 			children = (
 				17DF329224C87D3500BCE2E3 /* Info.plist */,
 				17DF329324C87D3500BCE2E3 /* macOS.entitlements */,
+				17BC617725715042003363CA /* Navigation */,
 				17A67CAC251A5D8D002F163D /* PostEditor */,
 				17A5388924DDA50500DEFF9A /* Settings */,
 				17B5103A2515448D00E9631F /* Credits.rtf */,
@@ -754,6 +765,7 @@
 				1753F6AC24E431CC00309365 /* MacPreferencesView.swift in Sources */,
 				1756DC0424FEE18400207AB8 /* WFACollection+CoreDataProperties.swift in Sources */,
 				17B996DB2502D23E0017B536 /* WFAPost+CoreDataProperties.swift in Sources */,
+				17BC618A25715318003363CA /* ActivePostToolbarView.swift in Sources */,
 				171BFDFB24D4AF8300888236 /* CollectionListView.swift in Sources */,
 				17A67CAF251A5DD7002F163D /* PostEditorView.swift in Sources */,
 				17DF32AB24C87D3500BCE2E3 /* WriteFreely_MultiPlatformApp.swift in Sources */,

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -8,10 +8,10 @@ struct ActivePostToolbarView: View {
         HStack(spacing: 16) {
             PostEditorStatusToolbarView(post: activePost)
             HStack(spacing: 4) {
-                Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
-                    .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
                 Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
                     .disabled(activePost.status == PostStatus.local.rawValue)
+                Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
+                    .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
             }
         }
     }

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct ActivePostToolbarView: View {
+    @EnvironmentObject var model: WriteFreelyModel
+    @ObservedObject var activePost: WFAPost
+
+    var body: some View {
+        HStack(spacing: 16) {
+            PostEditorStatusToolbarView(post: activePost)
+            HStack(spacing: 4) {
+                Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
+                    .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
+                Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
+                    .disabled(activePost.status == PostStatus.local.rawValue)
+            }
+        }
+    }
+
+    private func publishPost(_ post: WFAPost) {
+        DispatchQueue.main.async {
+            LocalStorageManager().saveContext()
+            model.publish(post: post)
+        }
+    }
+}

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -39,6 +39,9 @@ struct PostEditorView: View {
             }
         })
         .onDisappear(perform: {
+            DispatchQueue.main.async {
+                model.editor.clearLastDraft()
+            }
             if post.title.count == 0
                 && post.body.count == 0
                 && post.status == PostStatus.local.rawValue

--- a/macOS/PostEditor/PostEditorView.swift
+++ b/macOS/PostEditor/PostEditorView.swift
@@ -15,26 +15,6 @@ struct PostEditorView: View {
         )
         .padding()
         .background(Color(NSColor.controlBackgroundColor))
-        .toolbar {
-            ToolbarItem(placement: .status) {
-                PostEditorStatusToolbarView(post: post)
-            }
-            ToolbarItem(placement: .primaryAction) {
-                Button(action: {
-                    if model.account.isLoggedIn {
-                        publishPost()
-                    } else {
-                        let mainMenu = NSApplication.shared.mainMenu
-                        let appMenuItem = mainMenu?.item(withTitle: "WriteFreely")
-                        let prefsItem = appMenuItem?.submenu?.item(withTitle: "Preferences…")
-                        NSApplication.shared.sendAction(prefsItem!.action!, to: prefsItem?.target, from: nil)
-                    }
-                }, label: {
-                    Image(systemName: "paperplane")
-                })
-                .disabled(post.status == PostStatus.published.rawValue || post.body.count == 0)
-            }
-        }
         .onChange(of: post.hasNewerRemoteCopy, perform: { _ in
             if !post.hasNewerRemoteCopy {
                 self.updatingFromServer = true
@@ -55,13 +35,6 @@ struct PostEditorView: View {
                 }
             }
         })
-    }
-
-    private func publishPost() {
-        DispatchQueue.main.async {
-            LocalStorageManager().saveContext()
-            model.publish(post: post)
-        }
     }
 }
 


### PR DESCRIPTION
Closes #128.

This PR doesn't yet include toolbar UI/UX (if any) to support moving posts between blogs (todo in #134). Demo of key toolbar functionality:

![wf-mac-toolbar-features](https://user-images.githubusercontent.com/387655/100486060-7d647b00-30d0-11eb-98ab-0fff761bd74e.gif)

This PR also adds a few menubar entries and keyboard shortcuts for some functions:

- File &rarr; New Local Draft (CMD + N)
- File &rarr; Reload From Server (CMD + R)
- View &rarr; Toggle Sidebar (CMD + OPT + S)

This PR also fixes #127.

Demo of some menu commands and the Edit &rarr; Delete fix:

![wf-mac-menubar-features](https://user-images.githubusercontent.com/387655/100486312-58bcd300-30d1-11eb-8619-21b21427f3b1.gif)

Some known issues remain and I'll open GitHub issues for them when this is merged in, as they're beyond the scope of this PR:

- [ ] The blog title and number of posts in the toolbar doesn't update unless you click on "All Posts" in the toolbar once after launch.
- [ ] The app sometimes crashes doing the above.
- [ ] The reload-from-server button occasionally disappears and (usually) animates back when a new blog is selected in the sidebar.