### PR TITLE
Show alert instead of sheet on logout

### DIFF
--- a/Shared/Account/AccountLogoutView.swift
+++ b/Shared/Account/AccountLogoutView.swift
@@ -43,22 +43,13 @@ struct AccountLogoutView: View {
                 Text("Log Out")
             })
         }
-        .sheet(isPresented: $isPresentingLogoutConfirmation) {
-            VStack {
-                Text("Log Out?")
-                    .font(.title)
-                Text("\(editedPostsWarningString)You won't lose any local posts. Are you sure?")
-                HStack {
-                    Button(action: model.logout, label: {
-                        Text("Log Out")
-                    })
-                    Button(action: {
-                        self.isPresentingLogoutConfirmation = false
-                    }, label: {
-                        Text("Cancel")
-                    }).keyboardShortcut(.cancelAction)
-                }
-            }
+        .alert(isPresented: $isPresentingLogoutConfirmation) {
+            Alert(
+                title: Text("Log Out?"),
+                message: Text("\(editedPostsWarningString)You won't lose any local posts. Are you sure?"),
+                primaryButton: .cancel(Text("Cancel"), action: { self.isPresentingLogoutConfirmation = false }),
+                secondaryButton: .destructive(Text("Log Out"), action: model.logout )
+            )
         }
         #endif
     }


### PR DESCRIPTION
Closes #126.

This PR trades the action sheet approach on iOS for a system alert; this also gives us access to standard `Alert.Button`s styling for `.cancel()` and `.destructive()`. The following screenshots show the adaptive messaging when there is one/multiple/no edited posts that would be lost by logging out.

<img width="444" alt="Screen Shot 2020-11-30 at 09 51 17" src="https://user-images.githubusercontent.com/387655/100630514-a10a0a00-32f8-11eb-8621-375daefc0898.png">

<img width="444" alt="Screen Shot 2020-11-30 at 09 51 43" src="https://user-images.githubusercontent.com/387655/100630537-ab2c0880-32f8-11eb-88e9-dcac7451932f.png">

<img width="444" alt="Screen Shot 2020-11-30 at 10 35 09" src="https://user-images.githubusercontent.com/387655/100630550-b0895300-32f8-11eb-866f-1da8a5db026f.png">