### PR TITLE
Add "Visit Support Forum" item to Help menu

### DIFF
--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -39,9 +39,16 @@ struct WriteFreely_MultiPlatformApp: App {
                 .disabled(!model.account.isLoggedIn)
                 .keyboardShortcut("r", modifiers: [.command])
             }
-            #if os(macOS)
             SidebarCommands()
-            #endif
+            CommandGroup(after: .help) {
+                Button("Visit Support Forum") {
+                    #if os(macOS)
+                    NSWorkspace().open(model.helpURL)
+                    #else
+                    UIApplication.shared.open(model.helpURL)
+                    #endif
+                }
+            }
         }
 
         #if os(macOS)


### PR DESCRIPTION
Closes #38.

This PR adds a "Visit Support Forum" item to the bottom of the Help menu as shown in the screenshot below. Clicking it will open the link to forum's Help category in the user's default browser.

<img width="890" alt="Screen capture of a Mac desktop showing the WriteFreely Help menu opened and Visit Support Forum entry selected" src="https://user-images.githubusercontent.com/387655/101023554-ecaef480-3540-11eb-8d77-7957264e6f72.png">

I added conditional logic to the button's action since CommandGroup is supported in both macOS and iOS; so we'll use the right API/framework to open the link depending on the platform.