### PR TITLE
Use published properties for selectedCollection and showAllPosts

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -14,6 +14,8 @@ class WriteFreelyModel: ObservableObject {
     @Published var isProcessingRequest: Bool = false
     @Published var hasNetworkConnection: Bool = true
     @Published var selectedPost: WFAPost?
+    @Published var selectedCollection: WFACollection?
+    @Published var showAllPosts: Bool = true
     @Published var isPresentingDeleteAlert: Bool = false
     @Published var isPresentingLoginErrorAlert: Bool = false
     @Published var isPresentingNetworkErrorAlert: Bool = false

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -51,25 +51,7 @@ struct ContentView: View {
             #endif
 
             #if os(macOS)
-            PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
-                .toolbar {
-                    ToolbarItemGroup(placement: .primaryAction) {
-                        if let selectedPost = model.selectedPost {
-                            ActivePostToolbarView(activePost: selectedPost)
-                                .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
-                                    Alert(
-                                        title: Text("Connection Error"),
-                                        message: Text("""
-                                            There is no internet connection at the moment. Please reconnect or try again later.
-                                            """),
-                                        dismissButton: .default(Text("OK"), action: {
-                                            model.isPresentingNetworkErrorAlert = false
-                                        })
-                                    )
-                                })
-                        }
-                    }
-                }
+            PostListView(selectedCollection: model.selectedCollection, showAllPosts: model.showAllPosts)
             #else
             PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
             #endif

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -104,6 +104,8 @@ struct PostListView: View {
         }
         .onDisappear {
             DispatchQueue.main.async {
+                model.selectedCollection = nil
+                model.showAllPosts = true
                 model.selectedPost = nil
             }
         }

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
Fixes #147.

(I think.)

This PR moves to using published properties for `selectedCollection` and `showAllPosts` in the WriteFreelyModel. I'm not 100% sure this solves the crashing bug, but it does seem to make the app far more stable and responsive, and I haven't seen a crash switching between blogs, Drafts, and All Posts.