### PR TITLE
Show ProgressView during network request

### DIFF
--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -51,26 +51,34 @@ struct ContentView: View {
             #endif
 
             #if os(macOS)
-            PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
-                .toolbar {
-                    ToolbarItemGroup(placement: .primaryAction) {
-                        if let selectedPost = model.selectedPost {
-                            ActivePostToolbarView(activePost: selectedPost)
-                                .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
-                                    Alert(
-                                        title: Text("Connection Error"),
-                                        message: Text("""
-                                            There is no internet connection at the moment. \
-                                            Please reconnect or try again later.
-                                            """),
-                                        dismissButton: .default(Text("OK"), action: {
-                                            model.isPresentingNetworkErrorAlert = false
-                                        })
-                                    )
-                                })
+            ZStack {
+                PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
+                    .toolbar {
+                        ToolbarItemGroup(placement: .primaryAction) {
+                            if let selectedPost = model.selectedPost {
+                                ActivePostToolbarView(activePost: selectedPost)
+                                    .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
+                                        Alert(
+                                            title: Text("Connection Error"),
+                                            message: Text("""
+                                                There is no internet connection at the moment. \
+                                                Please reconnect or try again later.
+                                                """),
+                                            dismissButton: .default(Text("OK"), action: {
+                                                model.isPresentingNetworkErrorAlert = false
+                                            })
+                                        )
+                                    })
+                            }
                         }
+                }
+                if model.isProcessingRequest {
+                    ZStack {
+                        Color(NSColor.controlBackgroundColor).opacity(0.75)
+                        ProgressView()
                     }
                 }
+            }
             #else
             PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
             #endif

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -60,7 +60,8 @@ struct ContentView: View {
                                     Alert(
                                         title: Text("Connection Error"),
                                         message: Text("""
-                                            There is no internet connection at the moment. Please reconnect or try again later.
+                                            There is no internet connection at the moment. \
+                                            Please reconnect or try again later.
                                             """),
                                         dismissButton: .default(Text("OK"), action: {
                                             model.isPresentingNetworkErrorAlert = false

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -1,6 +1,21 @@
 import SwiftUI
 
 @main
+struct CheckForDebugModifier {
+    static func main() {
+        #if os(macOS)
+            if NSEvent.modifierFlags.contains(.shift) {
+                print("Debug launch detected")
+                // Run debug-mode launch code here
+            } else {
+                print("Normal launch detected")
+                // Don't do anything
+            }
+        #endif
+        WriteFreely_MultiPlatformApp.main()
+    }
+}
+
 struct WriteFreely_MultiPlatformApp: App {
     @StateObject private var model = WriteFreelyModel()
 


### PR DESCRIPTION
Closes #129.

This PR dims the post list and overlays a ProgressView spinner while a network request is running, as shown below. It also adds a way to run debug code (not currently implemented) on launch by holding the <kbd>Shift</kbd> key while the app is starting.

Light scheme:

![light-mode-progressview](https://user-images.githubusercontent.com/387655/101401656-a7702700-38a0-11eb-96ce-3912054b7c20.gif)

Dark scheme:

![dark-mode-progressview](https://user-images.githubusercontent.com/387655/101401679-accd7180-38a0-11eb-8055-991284a2498f.gif)