### PR TITLE
Improve new-post reliability

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -14,6 +14,8 @@ class WriteFreelyModel: ObservableObject {
     @Published var isProcessingRequest: Bool = false
     @Published var hasNetworkConnection: Bool = true
     @Published var selectedPost: WFAPost?
+    @Published var selectedCollection: WFACollection?
+    @Published var showAllPosts: Bool = true
     @Published var isPresentingDeleteAlert: Bool = false
     @Published var isPresentingLoginErrorAlert: Bool = false
     @Published var isPresentingNetworkErrorAlert: Bool = false

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -51,25 +51,7 @@ struct ContentView: View {
             #endif
 
             #if os(macOS)
-            PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
-                .toolbar {
-                    ToolbarItemGroup(placement: .primaryAction) {
-                        if let selectedPost = model.selectedPost {
-                            ActivePostToolbarView(activePost: selectedPost)
-                                .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
-                                    Alert(
-                                        title: Text("Connection Error"),
-                                        message: Text("""
-                                            There is no internet connection at the moment. Please reconnect or try again later.
-                                            """),
-                                        dismissButton: .default(Text("OK"), action: {
-                                            model.isPresentingNetworkErrorAlert = false
-                                        })
-                                    )
-                                })
-                        }
-                    }
-                }
+            PostListView(selectedCollection: model.selectedCollection, showAllPosts: model.showAllPosts)
             #else
             PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
             #endif

--- a/Shared/PostList/PostListFilteredView.swift
+++ b/Shared/PostList/PostListFilteredView.swift
@@ -87,7 +87,16 @@ struct PostListFilteredView: View {
                     tag: post,
                     selection: $model.selectedPost
                 ) {
-                    PostCellView(post: post)
+                    if showAllPosts {
+                        if let collection = collections.filter { $0.alias == post.collectionAlias }.first {
+                            PostCellView(post: post, collectionName: collection.title)
+                        } else {
+                            let collectionName = model.account.server == "https://write.as" ? "Anonymous" : "Drafts"
+                            PostCellView(post: post, collectionName: collectionName)
+                        }
+                    } else {
+                        PostCellView(post: post)
+                    }
                 }
                 .deleteDisabled(post.status != PostStatus.local.rawValue)
             }

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -104,6 +104,8 @@ struct PostListView: View {
         }
         .onDisappear {
             DispatchQueue.main.async {
+                model.selectedCollection = nil
+                model.showAllPosts = true
                 model.selectedPost = nil
             }
         }

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -104,9 +104,9 @@ struct PostListView: View {
         }
         .onDisappear {
             DispatchQueue.main.async {
-                model.selectedCollection = nil
-                model.showAllPosts = true
-                model.selectedPost = nil
+                self.model.selectedCollection = nil
+                self.model.showAllPosts = true
+                self.model.selectedPost = nil
             }
         }
         .navigationTitle(

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
Closes #131.

This PR improves the reliability of creating a new post. To really get proper navigation flow between the sidebar blog list, the central post list, and the post editor, a rethinking of the way state is coordinated is required, and that's beyond the scope of this work.