### PR TITLE
Add share feature

### DIFF
--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		173E19D1254318F600440F0F /* RemoteChangePromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173E19D0254318F600440F0F /* RemoteChangePromptView.swift */; };
 		173E19E3254329CC00440F0F /* PostTextEditingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173E19E2254329CC00440F0F /* PostTextEditingView.swift */; };
 		17466626256C0D0600629997 /* MacEditorTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17466625256C0D0600629997 /* MacEditorTextView.swift */; };
+		17479F152583D8E40072B7FB /* PostEditorSharingPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17479F142583D8E40072B7FB /* PostEditorSharingPicker.swift */; };
 		17480CA5251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */; };
 		17480CA6251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */; };
 		174D313224EC2831006CA9EE /* WriteFreelyModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174D313124EC2831006CA9EE /* WriteFreelyModel.swift */; };
@@ -126,6 +127,7 @@
 		173E19D0254318F600440F0F /* RemoteChangePromptView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteChangePromptView.swift; sourceTree = "<group>"; };
 		173E19E2254329CC00440F0F /* PostTextEditingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTextEditingView.swift; sourceTree = "<group>"; };
 		17466625256C0D0600629997 /* MacEditorTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacEditorTextView.swift; sourceTree = "<group>"; };
+		17479F142583D8E40072B7FB /* PostEditorSharingPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorSharingPicker.swift; sourceTree = "<group>"; };
 		17480CA4251272EE00EB7765 /* Bundle+AppVersion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+AppVersion.swift"; sourceTree = "<group>"; };
 		174D313124EC2831006CA9EE /* WriteFreelyModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteFreelyModel.swift; sourceTree = "<group>"; };
 		1753F6AB24E431CC00309365 /* MacPreferencesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacPreferencesView.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 				17A67CAE251A5DD7002F163D /* PostEditorView.swift */,
 				17E5DF892543610700DCDC9B /* PostTextEditingView.swift */,
 				17466625256C0D0600629997 /* MacEditorTextView.swift */,
+				17479F142583D8E40072B7FB /* PostEditorSharingPicker.swift */,
 			);
 			path = PostEditor;
 			sourceTree = "<group>";
@@ -755,6 +758,7 @@
 				17D435E924E3128F0036B539 /* PreferencesModel.swift in Sources */,
 				17120DAA24E1B2F5002B9F6C /* AccountLogoutView.swift in Sources */,
 				17DF32D624C8CA3400BCE2E3 /* PostStatusBadgeView.swift in Sources */,
+				17479F152583D8E40072B7FB /* PostEditorSharingPicker.swift in Sources */,
 				17480CA6251272EE00EB7765 /* Bundle+AppVersion.swift in Sources */,
 				17C42E662509237800072984 /* PostListFilteredView.swift in Sources */,
 				17120DAD24E1B99F002B9F6C /* AccountLoginView.swift in Sources */,

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -313,10 +313,10 @@
 		17A67CAC251A5D8D002F163D /* PostEditor */ = {
 			isa = PBXGroup;
 			children = (
+				17479F142583D8E40072B7FB /* PostEditorSharingPicker.swift */,
 				17A67CAE251A5DD7002F163D /* PostEditorView.swift */,
 				17E5DF892543610700DCDC9B /* PostTextEditingView.swift */,
 				17466625256C0D0600629997 /* MacEditorTextView.swift */,
-				17479F142583D8E40072B7FB /* PostEditorSharingPicker.swift */,
 			);
 			path = PostEditor;
 			sourceTree = "<group>";

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -17,7 +17,10 @@ struct ActivePostToolbarView: View {
                 )
                 .disabled(activePost.status == PostStatus.local.rawValue)
                 .popover(isPresented: $isPresentingSharingServicePicker) {
-                    PostEditorSharingPicker(sharingItems: createPostUrl())
+                    PostEditorSharingPicker(
+                        isPresented: $isPresentingSharingServicePicker,
+                        sharingItems: createPostUrl()
+                    )
                 }
                 Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
                     .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -21,6 +21,7 @@ struct ActivePostToolbarView: View {
                         isPresented: $isPresentingSharingServicePicker,
                         sharingItems: createPostUrl()
                     )
+                    .frame(width: .zero, height: .zero)
                 }
                 Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
                     .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -10,15 +10,14 @@ struct ActivePostToolbarView: View {
             PostEditorStatusToolbarView(post: activePost)
             HStack(spacing: 4) {
                 Button(
-                    action: { self.isPresentingSharingServicePicker = true },
+                    action: {
+                        self.isPresentingSharingServicePicker = true
+                    },
                     label: { Image(systemName: "square.and.arrow.up") }
                 )
                 .disabled(activePost.status == PostStatus.local.rawValue)
                 .popover(isPresented: $isPresentingSharingServicePicker) {
-                    PostEditorSharingPicker(
-                        isPresented: $isPresentingSharingServicePicker,
-                        sharingItems: createPostUrl()
-                    )
+                    PostEditorSharingPicker(sharingItems: createPostUrl())
                 }
                 Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
                     .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -3,17 +3,36 @@ import SwiftUI
 struct ActivePostToolbarView: View {
     @EnvironmentObject var model: WriteFreelyModel
     @ObservedObject var activePost: WFAPost
+    @State private var isPresentingSharingServicePicker: Bool = false
 
     var body: some View {
         HStack(spacing: 16) {
             PostEditorStatusToolbarView(post: activePost)
             HStack(spacing: 4) {
-                Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
-                    .disabled(activePost.status == PostStatus.local.rawValue)
+                Button(
+                    action: { self.isPresentingSharingServicePicker = true },
+                    label: { Image(systemName: "square.and.arrow.up") }
+                )
+                .disabled(activePost.status == PostStatus.local.rawValue)
+                .popover(isPresented: $isPresentingSharingServicePicker) {
+                    PostEditorSharingPicker(
+                        isPresented: $isPresentingSharingServicePicker,
+                        sharingItems: createPostUrl()
+                    )
+                }
                 Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
                     .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
             }
         }
+    }
+
+    private func createPostUrl() -> [Any] {
+        guard let postId = activePost.postId else { return [] }
+        guard let urlString = activePost.slug != nil ?
+                "\(model.account.server)/\((activePost.collectionAlias)!)/\((activePost.slug)!)" :
+                "\(model.account.server)/\((postId))" else { return [] }
+        guard let data = URL(string: urlString) else { return [] }
+        return [data as NSURL]
     }
 
     private func publishPost(_ post: WFAPost) {

--- a/macOS/PostEditor/PostEditorSharingPicker.swift
+++ b/macOS/PostEditor/PostEditorSharingPicker.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct PostEditorSharingPicker: NSViewRepresentable {
+    @Binding var isPresented: Bool
     var sharingItems: [Any] = []
 
     func makeNSView(context: Context) -> some NSView {
@@ -32,6 +33,7 @@ struct PostEditorSharingPicker: NSViewRepresentable {
             didChoose service: NSSharingService?
         ) {
             sharingServicePicker.delegate = nil
+            self.owner.isPresented = false
         }
     }
 }

--- a/macOS/PostEditor/PostEditorSharingPicker.swift
+++ b/macOS/PostEditor/PostEditorSharingPicker.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+struct PostEditorSharingPicker: NSViewRepresentable {
+    @Binding var isPresented: Bool
+    var sharingItems: [Any] = []
+
+    func makeNSView(context: Context) -> some NSView {
+        let view = NSView()
+        return view
+    }
+
+    func updateNSView(_ nsView: NSViewType, context: Context) {
+        if isPresented {
+            let picker = NSSharingServicePicker(items: sharingItems)
+            picker.delegate = context.coordinator
+
+            DispatchQueue.main.async {
+                picker.show(relativeTo: .zero, of: nsView, preferredEdge: .minY)
+            }
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(owner: self)
+    }
+
+    class Coordinator: NSObject, NSSharingServicePickerDelegate {
+        let owner: PostEditorSharingPicker
+        init(owner: PostEditorSharingPicker) {
+            self.owner = owner
+        }
+
+        func sharingServicePicker(
+            _ sharingServicePicker: NSSharingServicePicker,
+            didChoose service: NSSharingService?
+        ) {
+            sharingServicePicker.delegate = nil     // Cleanup
+            self.owner.isPresented = false          // Dismiss
+        }
+    }
+}

--- a/macOS/PostEditor/PostEditorSharingPicker.swift
+++ b/macOS/PostEditor/PostEditorSharingPicker.swift
@@ -1,23 +1,20 @@
 import SwiftUI
 
 struct PostEditorSharingPicker: NSViewRepresentable {
-    @Binding var isPresented: Bool
     var sharingItems: [Any] = []
 
     func makeNSView(context: Context) -> some NSView {
         let view = NSView()
+        let picker = NSSharingServicePicker(items: sharingItems)
+        picker.delegate = context.coordinator
+
+        DispatchQueue.main.async {
+            picker.show(relativeTo: .zero, of: view, preferredEdge: .minY)
+        }
         return view
     }
 
     func updateNSView(_ nsView: NSViewType, context: Context) {
-        if isPresented {
-            let picker = NSSharingServicePicker(items: sharingItems)
-            picker.delegate = context.coordinator
-
-            DispatchQueue.main.async {
-                picker.show(relativeTo: .zero, of: nsView, preferredEdge: .minY)
-            }
-        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -34,8 +31,7 @@ struct PostEditorSharingPicker: NSViewRepresentable {
             _ sharingServicePicker: NSSharingServicePicker,
             didChoose service: NSSharingService?
         ) {
-            sharingServicePicker.delegate = nil     // Cleanup
-            self.owner.isPresented = false          // Dismiss
+            sharingServicePicker.delegate = nil
         }
     }
 }


### PR DESCRIPTION
Closes #81.

This PR sends the post's URL to the system sharing service. I can conceive of future enhancements that can send either the URL, or the raw Markdown, for example.

![share-picker](https://user-images.githubusercontent.com/387655/101954593-5aef5900-3bca-11eb-941c-d16fe7fbf53a.gif)
