### PR TITLE
Add help tooltips to the toolbar buttons

### DIFF
--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -16,6 +16,7 @@ struct ContentView: View {
                         },
                         label: { Image(systemName: "sidebar.left") }
                     )
+                    .help("Toggle the sidebar's visibility.")
                     Spacer()
                     Button(action: {
                         withAnimation {
@@ -45,6 +46,7 @@ struct ContentView: View {
                             }
                         }
                     }, label: { Image(systemName: "square.and.pencil") })
+                    .help("Create a new local draft.")
                 }
             #else
             SidebarView()

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -13,7 +13,7 @@ struct ActivePostToolbarView: View {
                     .help("Copy the post's URL to your Mac's pasteboard.")
                 Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
                     .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
-                    .help("Publish the post to the web. You must be logged in to do this.")
+                    .help("Publish the post to the web.\(model.account.isLoggedIn ? "" : "You must be logged in to do this.")") // swiftlint:disable:this line_length
             }
         }
     }

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -10,8 +10,10 @@ struct ActivePostToolbarView: View {
             HStack(spacing: 4) {
                 Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
                     .disabled(activePost.status == PostStatus.local.rawValue)
+                    .help("Copy the post's URL to your Mac's pasteboard.")
                 Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
                     .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
+                    .help("Publish the post to the web. You must be logged in to do this.")
             }
         }
     }


### PR DESCRIPTION
Closes #154.

Hovering over the toolbar buttons for an instant will show the messages in the `.help()` modifier for that button.