### PR TITLE
Extend toolbar for move-to and publish-to functionality

### DIFF
--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -53,25 +53,6 @@ struct ContentView: View {
             #if os(macOS)
             ZStack {
                 PostListView(selectedCollection: nil, showAllPosts: model.account.isLoggedIn)
-                    .toolbar {
-                        ToolbarItemGroup(placement: .primaryAction) {
-                            if let selectedPost = model.selectedPost {
-                                ActivePostToolbarView(activePost: selectedPost)
-                                    .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
-                                        Alert(
-                                            title: Text("Connection Error"),
-                                            message: Text("""
-                                                There is no internet connection at the moment. \
-                                                Please reconnect or try again later.
-                                                """),
-                                            dismissButton: .default(Text("OK"), action: {
-                                                model.isPresentingNetworkErrorAlert = false
-                                            })
-                                        )
-                                    })
-                            }
-                        }
-                }
                 if model.isProcessingRequest {
                     ZStack {
                         Color(NSColor.controlBackgroundColor).opacity(0.75)

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -84,24 +84,6 @@ struct PostListView: View {
             showAllPosts: showAllPosts,
             postCount: $postCount
         )
-        .toolbar {
-            ToolbarItemGroup(placement: .primaryAction) {
-                if let selectedPost = model.selectedPost {
-                    ActivePostToolbarView(activePost: selectedPost)
-                        .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
-                            Alert(
-                                title: Text("Connection Error"),
-                                message: Text("""
-                                    There is no internet connection at the moment. Please reconnect or try again later.
-                                    """),
-                                dismissButton: .default(Text("OK"), action: {
-                                    model.isPresentingNetworkErrorAlert = false
-                                })
-                            )
-                        })
-                }
-            }
-        }
         .onDisappear {
             DispatchQueue.main.async {
                 self.model.selectedCollection = nil

--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -84,6 +84,25 @@ struct PostListView: View {
             showAllPosts: showAllPosts,
             postCount: $postCount
         )
+        .toolbar {
+            ToolbarItemGroup(placement: .primaryAction) {
+                if let selectedPost = model.selectedPost {
+                    ActivePostToolbarView(activePost: selectedPost)
+                        .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
+                            Alert(
+                                title: Text("Connection Error"),
+                                message: Text("""
+                                    There is no internet connection at the moment. \
+                                    Please reconnect or try again later.
+                                    """),
+                                dismissButton: .default(Text("OK"), action: {
+                                    model.isPresentingNetworkErrorAlert = false
+                                })
+                            )
+                        })
+                }
+            }
+        }
         .onDisappear {
             DispatchQueue.main.async {
                 self.model.selectedCollection = nil

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -55,6 +55,7 @@ struct WriteFreely_MultiPlatformApp: App {
                 .keyboardShortcut("r", modifiers: [.command])
             }
             SidebarCommands()
+            PostCommands(post: model.selectedPost)
             CommandGroup(after: .help) {
                 Button("Visit Support Forum") {
                     #if os(macOS)

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -55,7 +55,7 @@ struct WriteFreely_MultiPlatformApp: App {
                 .keyboardShortcut("r", modifiers: [.command])
             }
             SidebarCommands()
-            PostCommands(post: model.selectedPost)
+            PostCommands(model: model)
             CommandGroup(after: .help) {
                 Button("Visit Support Forum") {
                     #if os(macOS)

--- a/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
+++ b/WriteFreely-MultiPlatform.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		1765F62A24E18EA200C9EBF0 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1765F62924E18EA200C9EBF0 /* SidebarView.swift */; };
 		1765F62B24E18EA200C9EBF0 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1765F62924E18EA200C9EBF0 /* SidebarView.swift */; };
 		17681E412519410E00D394AE /* UINavigationController+Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17681E402519410E00D394AE /* UINavigationController+Appearance.swift */; };
+		1780F6EF25895EDB00FE45FF /* PostCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1780F6EE25895EDB00FE45FF /* PostCommands.swift */; };
 		17A5388824DDA31F00DEFF9A /* MacAccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5388724DDA31F00DEFF9A /* MacAccountView.swift */; };
 		17A5388C24DDC83F00DEFF9A /* AccountModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5388B24DDC83F00DEFF9A /* AccountModel.swift */; };
 		17A5388F24DDEC7400DEFF9A /* AccountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17A5388D24DDEC7400DEFF9A /* AccountView.swift */; };
@@ -141,6 +142,7 @@
 		1756DC0024FEE18400207AB8 /* WFACollection+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WFACollection+CoreDataProperties.swift"; sourceTree = SOURCE_ROOT; };
 		1765F62924E18EA200C9EBF0 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		17681E402519410E00D394AE /* UINavigationController+Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Appearance.swift"; sourceTree = "<group>"; };
+		1780F6EE25895EDB00FE45FF /* PostCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCommands.swift; sourceTree = "<group>"; };
 		17A5388724DDA31F00DEFF9A /* MacAccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MacAccountView.swift; sourceTree = "<group>"; };
 		17A5388B24DDC83F00DEFF9A /* AccountModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountModel.swift; sourceTree = "<group>"; };
 		17A5388D24DDEC7400DEFF9A /* AccountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountView.swift; sourceTree = "<group>"; };
@@ -322,6 +324,7 @@
 			isa = PBXGroup;
 			children = (
 				17BC617825715068003363CA /* ActivePostToolbarView.swift */,
+				1780F6EE25895EDB00FE45FF /* PostCommands.swift */,
 			);
 			path = Navigation;
 			sourceTree = "<group>";
@@ -777,6 +780,7 @@
 				1756DC0224FEE18400207AB8 /* WFACollection+CoreDataClass.swift in Sources */,
 				1756DBB424FECDBB00207AB8 /* PostEditorStatusToolbarView.swift in Sources */,
 				17A5388F24DDEC7400DEFF9A /* AccountView.swift in Sources */,
+				1780F6EF25895EDB00FE45FF /* PostCommands.swift in Sources */,
 				170DFA35251BBC44001D82A0 /* PostEditorModel.swift in Sources */,
 				1756AE7524CB26FA00FD7257 /* PostCellView.swift in Sources */,
 				17A5388824DDA31F00DEFF9A /* MacAccountView.swift in Sources */,

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -12,8 +12,10 @@ struct ActivePostToolbarView: View {
     ) var collections: FetchedResults<WFACollection>
 
     var body: some View {
-        HStack(spacing: 4) {
-            if model.account.isLoggedIn && activePost.status != PostStatus.local.rawValue {
+        HStack {
+            if model.account.isLoggedIn &&
+                activePost.status != PostStatus.local.rawValue &&
+                !(activePost.wasDeletedFromServer || activePost.hasNewerRemoteCopy) {
                 Section(header: Text("Move To:")) {
                     Picker(selection: $selectedCollection, label: Text("Move To…"), content: {
                         Text("\(model.account.server == "https://write.as" ? "Anonymous" : "Drafts")")
@@ -26,12 +28,51 @@ struct ActivePostToolbarView: View {
                 }
             }
             PostEditorStatusToolbarView(post: activePost)
+                .frame(minWidth: 50, alignment: .center)
                 .layoutPriority(1)
                 .padding(.horizontal)
-            Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
-                .disabled(activePost.status == PostStatus.local.rawValue)
-            Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
-                .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
+            if activePost.status == PostStatus.local.rawValue {
+                Menu(content: {
+                    Label("Publish To:", systemImage: "paperplane")
+                    Divider()
+                    Button(action: {
+                        if model.account.isLoggedIn {
+                            withAnimation {
+                                activePost.collectionAlias = nil
+                                publishPost(activePost)
+                            }
+                        } else {
+                            // present login screen
+                        }
+                    }, label: {
+                        Text("\(model.account.server == "https://write.as" ? "Anonymous" : "Drafts")")
+                    })
+                    ForEach(collections) { collection in
+                        Button(action: {
+                            if model.account.isLoggedIn {
+                                withAnimation {
+                                    activePost.collectionAlias = collection.alias
+                                    publishPost(activePost)
+                                }
+                            } else {
+                                // present login screen
+                            }
+                        }, label: {
+                            Text("\(collection.title)")
+                        })
+                    }
+                }, label: {
+                    Label("Publish…", systemImage: "paperplane")
+                })
+                .disabled(activePost.body.isEmpty)
+            } else {
+                HStack(spacing: 4) {
+                    Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
+                        .disabled(activePost.status == PostStatus.local.rawValue)
+                    Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
+                        .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
+                }
+            }
         }
         .onAppear(perform: {
             self.selectedCollection = collections.first { $0.alias == activePost.collectionAlias }

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -42,7 +42,7 @@ struct ActivePostToolbarView: View {
                                 publishPost(activePost)
                             }
                         } else {
-                            // present login screen
+                            openSettingsWindow()
                         }
                     }, label: {
                         Text("\(model.account.server == "https://write.as" ? "Anonymous" : "Drafts")")
@@ -55,7 +55,7 @@ struct ActivePostToolbarView: View {
                                     publishPost(activePost)
                                 }
                             } else {
-                                // present login screen
+                                openSettingsWindow()
                             }
                         }, label: {
                             Text("\(collection.title)")
@@ -94,5 +94,10 @@ struct ActivePostToolbarView: View {
             LocalStorageManager().saveContext()
             model.publish(post: post)
         }
+    }
+
+    private func openSettingsWindow() {
+        guard let menuItem = NSApplication.shared.mainMenu?.item(at: 0)?.submenu?.item(at: 2) else { return }
+        NSApplication.shared.sendAction(menuItem.action!, to: menuItem.target, from: nil)
     }
 }

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -12,7 +12,7 @@ struct ActivePostToolbarView: View {
     ) var collections: FetchedResults<WFACollection>
 
     var body: some View {
-        HStack {
+        HStack(spacing: 4) {
             if model.account.isLoggedIn && activePost.status != PostStatus.local.rawValue {
                 Section(header: Text("Move To:")) {
                     Picker(selection: $selectedCollection, label: Text("Move To…"), content: {
@@ -27,12 +27,11 @@ struct ActivePostToolbarView: View {
             }
             PostEditorStatusToolbarView(post: activePost)
                 .layoutPriority(1)
-            HStack(spacing: 4) {
-                Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
-                    .disabled(activePost.status == PostStatus.local.rawValue)
-                Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
-                    .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
-            }
+                .padding(.horizontal)
+            Button(action: {}, label: { Image(systemName: "square.and.arrow.up") })
+                .disabled(activePost.status == PostStatus.local.rawValue)
+            Button(action: { publishPost(activePost) }, label: { Image(systemName: "paperplane") })
+                .disabled(activePost.body.isEmpty || activePost.status == PostStatus.published.rawValue)
         }
         .onAppear(perform: {
             self.selectedCollection = collections.first { $0.alias == activePost.collectionAlias }

--- a/macOS/Navigation/PostCommands.swift
+++ b/macOS/Navigation/PostCommands.swift
@@ -3,22 +3,9 @@ import SwiftUI
 struct PostCommands: Commands {
     @ObservedObject var model: WriteFreelyModel
 
-    @FetchRequest(
-        entity: WFACollection.entity(),
-        sortDescriptors: [NSSortDescriptor(keyPath: \WFACollection.title, ascending: true)]
-    ) var collections: FetchedResults<WFACollection>
-
     var body: some Commands {
         CommandMenu("Post") {
             Group {
-                Button("Publish…") {
-                    print("Clicked 'Publish…' for post '\(model.selectedPost?.title ?? "untitled")'")
-                }
-                .disabled(true)
-                Button("Move…") {
-                    print("Clicked 'Move…' for post '\(model.selectedPost?.title ?? "untitled")'")
-                }
-                .disabled(true)
                 Button(action: sendPostUrlToPasteboard, label: { Text("Copy Link To Published Post") })
                     .disabled(model.selectedPost?.status == PostStatus.local.rawValue)
             }

--- a/macOS/Navigation/PostCommands.swift
+++ b/macOS/Navigation/PostCommands.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct PostCommands: Commands {
+    @State var post: WFAPost?
+
+    var body: some Commands {
+        CommandMenu("Post") {
+            Button("Publish…") {
+                print("Published active post (not really): '\(post?.title ?? "untitled")'")
+            }
+            Button("Move…") {
+                print("Moved active post (not really): '\(post?.title ?? "untitled")'")
+            }
+            Button("Copy Link To Post") {
+                print("Copied URL to post (not really): '\(post?.title ?? "untitled")'")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #134.

This PR implements the following:

A "move-to" dropdown menu for published posts, that pre-selects the blog that the post is published to, and lets you move to another simply by selecting another blog (or Drafts) in the list.

<img width="1414" alt="Screen Shot 2020-12-17 at 12 04 03" src="https://user-images.githubusercontent.com/387655/102519691-d46ec780-4060-11eb-9b6e-9864189fa88e.png">

A "publish-to" dropdown menu for local posts whose body is not empty, allowing you to publish the local post to the blog of your choice.

<img width="1541" alt="Screen Shot 2020-12-17 at 12 04 46" src="https://user-images.githubusercontent.com/387655/102519823-fd8f5800-4060-11eb-9e5e-497cb3649415.png">

A Post menu item with, currently, a single command: _Copy Link To Published Post_, which writes a link to the post to the Mac's pasteboard. This specific menu command is disabled if the post is only local; the entire Post menu is disabled if no post is selected, or if the user is not logged in.