### PR TITLE
Add link to write a review in the App Store

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -29,6 +29,7 @@ class WriteFreelyModel: ObservableObject {
     // swiftlint:disable line_length
     let helpURL = URL(string: "https://discuss.write.as/c/help/5")!
     let howToURL = URL(string: "https://discuss.write.as/t/using-the-writefreely-ios-app/1946")!
+    let reviewURL = URL(string: "https://apps.apple.com/app/id1531530896?action=write-review")!
     let licensesURL = URL(string: "https://github.com/writeas/writefreely-swiftui-multiplatform/tree/main/Shared/Resources/Licenses")!
     // swiftlint:enable line_length
 

--- a/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/WriteFreely-MultiPlatform.xcodeproj/xcuserdata/angelo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,12 @@
 		<key>WriteFreely-MultiPlatform (iOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 		<key>WriteFreely-MultiPlatform (macOS).xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 </dict>

--- a/iOS/Settings/SettingsView.swift
+++ b/iOS/Settings/SettingsView.swift
@@ -13,7 +13,7 @@ struct SettingsView: View {
                 Section(header: Text("Appearance")) {
                     PreferencesView(preferences: model.preferences)
                 }
-                Section(header: Text("Support Links")) {
+                Section(header: Text("External Links")) {
                     HStack {
                         Spacer()
                         Link("View the Guide", destination: model.howToURL)
@@ -22,6 +22,11 @@ struct SettingsView: View {
                     HStack {
                         Spacer()
                         Link("Visit the Help Forum", destination: model.helpURL)
+                        Spacer()
+                    }
+                    HStack {
+                        Spacer()
+                        Link("Write a Review on the App Store", destination: model.reviewURL)
                         Spacer()
                     }
                 }


### PR DESCRIPTION
This PR is not linked to any issues. It's fairly straightforward, in that it:

1. Renames the "Support Links" section in the settings sheet to "External Links";
2. Adds a link that opens the App Store and passes a query paramter to bring up the write-a-review sheet.

Only users that have purchased the app can write a review; if they haven't (i.e., TestFlight testers or built from source), they'll see an alert telling them as much: 

<img src="https://user-images.githubusercontent.com/387655/103571964-d1196f80-4e99-11eb-8547-32128d940a69.jpeg" width="375" />
