### PR TITLE
Fix post-status bug on publishing changes

### DIFF
--- a/Shared/PostList/PostListView.swift
+++ b/Shared/PostList/PostListView.swift
@@ -112,19 +112,21 @@ struct PostListView: View {
         )
         .toolbar {
             ToolbarItemGroup(placement: .primaryAction) {
-                ActivePostToolbarView()
-                    .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
-                        Alert(
-                            title: Text("Connection Error"),
-                            message: Text("""
+                if model.selectedPost != nil {
+                    ActivePostToolbarView(activePost: model.selectedPost!)
+                        .alert(isPresented: $model.isPresentingNetworkErrorAlert, content: {
+                            Alert(
+                                title: Text("Connection Error"),
+                                message: Text("""
                                     There is no internet connection at the moment. \
                                     Please reconnect or try again later.
                                     """),
-                            dismissButton: .default(Text("OK"), action: {
-                                model.isPresentingNetworkErrorAlert = false
-                            })
-                        )
-                    })
+                                dismissButton: .default(Text("OK"), action: {
+                                    model.isPresentingNetworkErrorAlert = false
+                                })
+                            )
+                        })
+                }
             }
         }
         .navigationTitle(

--- a/macOS/Navigation/ActivePostToolbarView.swift
+++ b/macOS/Navigation/ActivePostToolbarView.swift
@@ -64,7 +64,7 @@ struct ActivePostToolbarView: View {
                 }, label: {
                     Label("Publish…", systemImage: "paperplane")
                 })
-                .disabled(model.selectedPost!.body.isEmpty)
+                .disabled(model.selectedPost?.body.isEmpty ?? true)
                 .help("Publish the post to the web.\(model.account.isLoggedIn ? "" : " You must be logged in to do this.")") // swiftlint:disable:this line_length
             } else {
                 HStack(spacing: 4) {
@@ -114,6 +114,9 @@ struct ActivePostToolbarView: View {
     }
 
     private func publishPost(_ post: WFAPost) {
+        if post != model.selectedPost {
+            return
+        }
         DispatchQueue.main.async {
             LocalStorageManager().saveContext()
             model.publish(post: post)


### PR DESCRIPTION
Closes #98.

This PR adds a way for the `publishHandler()` to differentiate between a call to create a new post or updating an existing post.