### PR TITLE
Add editing menu, enable find/replace, ignore formatted text on paste

### DIFF
--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -94,6 +94,8 @@ struct WriteFreely_MultiPlatformApp: App {
                     #endif
                 }
             }
+            ToolbarCommands()
+            TextEditingCommands()
         }
 
         #if os(macOS)

--- a/macOS/PostEditor/MacEditorTextView.swift
+++ b/macOS/PostEditor/MacEditorTextView.swift
@@ -140,7 +140,8 @@ final class CustomTextView: NSView {
         layoutManager.addTextContainer(textContainer)
 
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = 8.5
+        let lineHeightMultiple: CGFloat = 1.5
+        paragraphStyle.lineHeightMultiple = lineHeightMultiple
 
         let textView = NSTextView(frame: .zero, textContainer: textContainer)
         textView.autoresizingMask = .width
@@ -158,6 +159,9 @@ final class CustomTextView: NSView {
         textView.minSize = NSSize(width: 0, height: contentSize.height)
         textView.textColor = NSColor.labelColor
         textView.allowsUndo = true
+        textView.usesFindPanel = true
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isRichText = false
 
         return textView
     }()


### PR DESCRIPTION
Unrelated to any issue.

This PR adds some Quality-Of-Life fixes to the Mac editor:

- Adds a menu command to show/hide the toolbar.
- Adds menu commands for text editing.
- Enables find/replace in the post editor.
- Turns off auto dash substitution, which replaces two dashes (`--`) with an em-dash (`—`) and makes entering shortcodes like `<!--more-->` more annoying than necessary.
- Disables rich text editing, so that text pasted into the editor is treated as plain text (i.e., forces "paste and match style").