### PR TITLE
Update createdDate to the current timestamp when publishing new post

### DIFF
--- a/Shared/Extensions/WriteFreelyModel+API.swift
+++ b/Shared/Extensions/WriteFreelyModel+API.swift
@@ -97,7 +97,7 @@ extension WriteFreelyModel {
             appearance: post.appearance,
             language: post.language,
             rtl: post.rtl,
-            createdDate: post.createdDate
+            createdDate: post.status == PostStatus.local.rawValue ? Date() : post.createdDate
         )
 
         if let existingPostId = post.postId {


### PR DESCRIPTION
Closes #171.

We set the `createdDate` property when a new local post is generate to sort the post list. When the `publish()` method is called, we update this property in the WFPost object that's created to send to the server. In this way, the local copy's `createdDate` property is only updated _if_ the publish action succeeds (i.e.,  from the server response).