### PR TITLE
Check for updates in background on launch

### DIFF
--- a/macOS/AppDelegate.swift
+++ b/macOS/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         // If enabled, check for updates.
         if automaticallyChecksForUpdates {
-            SUUpdater.shared()?.checkForUpdates(self)
+            SUUpdater.shared()?.checkForUpdatesInBackground()
         }
     }
 }


### PR DESCRIPTION
Closes #174.

This PR switches to the aptly-named `.checkForUpdatesInBackground()` in the AppDelegate, to check for updates silently on launch. From the SUUpdater.h header file:

```
/*!
 Checks for updates, but does not display any UI unless an update is found.
 This is meant for programmatically initating a check for updates. That is,
 it will display no UI unless it actually finds an update, in which case it
 proceeds as usual.
 If automatic downloading of updates it turned on and allowed, however,
 this will invoke that behavior, and if an update is found, it will be downloaded
 in the background silently and will be prepped for installation.
 This will not find updates that the user has opted into skipping.
 */
- (void)checkForUpdatesInBackground;
```

[Source](https://github.com/sparkle-project/Sparkle/blob/c7c90d4d1de8cd7fb01683c77b609c3e98afe1cb/Sparkle/SUUpdater.h#L73-L86)