### PR TITLE
Bugfix mac crash

### DIFF
--- a/Shared/Models/WriteFreelyModel.swift
+++ b/Shared/Models/WriteFreelyModel.swift
@@ -24,6 +24,8 @@ final class WriteFreelyModel: ObservableObject {
     @Published var isPresentingSettingsView: Bool = false
     #endif
 
+    static var shared = WriteFreelyModel()
+
     var loginErrorMessage: String?
 
     // swiftlint:disable line_length

--- a/Shared/Navigation/ContentView.swift
+++ b/Shared/Navigation/ContentView.swift
@@ -22,10 +22,6 @@ struct ContentView: View {
                         withAnimation {
                             // Un-set the currently selected post
                             self.model.selectedPost = nil
-
-                            // Navigate to the Drafts list
-                            self.model.showAllPosts = false
-                            self.model.selectedCollection = nil
                         }
                         // Create the new-post managed object
                         let managedPost = model.editor.generateNewLocalPost(withFont: model.preferences.font)

--- a/Shared/PostEditor/PostEditorModel.swift
+++ b/Shared/PostEditor/PostEditorModel.swift
@@ -32,7 +32,7 @@ struct PostEditorModel {
         managedPost.title = ""
         managedPost.body = ""
         managedPost.status = PostStatus.local.rawValue
-        managedPost.collectionAlias = nil
+        managedPost.collectionAlias = WriteFreelyModel.shared.selectedCollection?.alias
         switch appearance {
         case 1:
             managedPost.appearance = "sans"

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -132,10 +132,6 @@ struct WriteFreely_MultiPlatformApp: App {
         withAnimation {
             // Un-set the currently selected post
             self.model.selectedPost = nil
-
-            // Navigate to the Drafts list
-            self.model.showAllPosts = false
-            self.model.selectedCollection = nil
         }
         // Create the new-post managed object
         let managedPost = model.editor.generateNewLocalPost(withFont: model.preferences.font)

--- a/Shared/WriteFreely_MultiPlatformApp.swift
+++ b/Shared/WriteFreely_MultiPlatformApp.swift
@@ -22,7 +22,7 @@ struct CheckForDebugModifier {
 }
 
 struct WriteFreely_MultiPlatformApp: App {
-    @StateObject private var model = WriteFreelyModel()
+    @StateObject private var model = WriteFreelyModel.shared
 
     #if os(macOS)
     // swiftlint:disable:next weak_delegate


### PR DESCRIPTION
Closes #173.

This PR changes the new-draft behaviour on the Mac, creating a new draft in the currently-selected collection, rather than changing the app's state to show the "Drafts" list (or "Anonymous" list, on Write.as accounts).

It also adds a timed autosave to the post editor: when a post is loaded in the editor, a one-second repeating timer kicks off on the main thread. It is blocked by typing events, so it will not fire while the user is typing. If the user is _not_ typing, it fires and checks to see if 1) the post's body is not empty, _and_ 2) if the post has been edited. If this condition is satisfied, the changes are saved to the local CoreData store.
