### PR TITLE
Update SUFeedURL for Sparkle updates

### DIFF
--- a/macOS/Info.plist
+++ b/macOS/Info.plist
@@ -29,7 +29,7 @@
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>SUFeedURL</key>
-	<string>https://writefreely-files.s3.amazonaws.com/apps/mac/appcast.xml</string>
+	<string>https://files.writefreely.org/apps/mac/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>xLenuurDaQb2/dj2ScylLmJx0gSnBmacUsOAgUjErUc=</string>
 </dict>


### PR DESCRIPTION
Use a URL that allows changing the hosting provider without require app updates.